### PR TITLE
fix: gracefully disable when grafanaCloudCatalogInfo config is absent

### DIFF
--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -1,4 +1,6 @@
 import { Entity } from '@backstage/catalog-model';
+import { Config } from '@backstage/config';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import {
   GrafanaServiceModelProcessor,
   entityToServiceModel,
@@ -124,4 +126,77 @@ it('should convert Group entity to service model', () => {
   expect((result.spec as { backstageMetadata: any }).backstageMetadata).toEqual(
     entity.metadata,
   );
+});
+
+describe('config absent', () => {
+  it('should not throw when grafanaCloudCatalogInfo config is missing', () => {
+    const mockConfig = {
+      has: (_key: string) => false,
+      getString: () => { throw new Error('not found'); },
+      getStringArray: () => { throw new Error('not found'); },
+      getBoolean: () => { throw new Error('not found'); },
+    } as unknown as Config;
+
+    const mockLogger = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    } as unknown as LoggerService;
+
+    expect(() => {
+      GrafanaServiceModelProcessor.fromConfig({ config: mockConfig, logger: mockLogger });
+    }).not.toThrow();
+  });
+
+  it('should log that it is disabled when config is absent', () => {
+    const mockConfig = {
+      has: (_key: string) => false,
+      getString: () => { throw new Error('not found'); },
+      getStringArray: () => { throw new Error('not found'); },
+      getBoolean: () => { throw new Error('not found'); },
+    } as unknown as Config;
+
+    const mockLogger = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    } as unknown as LoggerService;
+
+    GrafanaServiceModelProcessor.fromConfig({ config: mockConfig, logger: mockLogger });
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining('No grafanaCloudCatalogInfo config found'),
+    );
+  });
+});
+
+describe('entity name validation', () => {
+  const nameRegex = /^[a-z0-9][a-z0-9\-.]*[a-z0-9]$/;
+
+  it('should accept valid K8s names', () => {
+    expect(nameRegex.test('my-service')).toBe(true);
+    expect(nameRegex.test('telemetry-gateway')).toBe(true);
+    expect(nameRegex.test('sqm-ingestor-kafka')).toBe(true);
+    expect(nameRegex.test('a1')).toBe(true);
+    expect(nameRegex.test('service.name.with.dots')).toBe(true);
+  });
+
+  it('should reject invalid K8s names', () => {
+    expect(nameRegex.test('')).toBe(false);
+    expect(nameRegex.test('-starts-with-dash')).toBe(false);
+    expect(nameRegex.test('ends-with-dash-')).toBe(false);
+    expect(nameRegex.test('.starts-with-dot')).toBe(false);
+    expect(nameRegex.test('has spaces')).toBe(false);
+    expect(nameRegex.test('HAS-UPPERCASE')).toBe(false);
+    expect(nameRegex.test('../../admin')).toBe(false);
+    expect(nameRegex.test('foo/bar')).toBe(false);
+    expect(nameRegex.test('a')).toBe(false); // single char - needs start AND end
+  });
+
+  it('should reject names longer than 253 characters', () => {
+    const longName = 'a'.repeat(254);
+    expect(longName.length > 253).toBe(true);
+    // The regex itself doesn't check length, but the code does
+  });
 });

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -104,6 +104,16 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
     this.config = config;
     this.grafanaAvailable = false;
 
+    // Gracefully disable if config block is absent (e.g. local development)
+    if (!config.has('grafanaCloudCatalogInfo')) {
+      this.enable = false;
+      this.filter = { key: '', values: [] } as unknown as EntityFilter;
+      logger.info(
+        'GrafanaServiceModelProcessor: No grafanaCloudCatalogInfo config found. Disabled.',
+      );
+      return;
+    }
+
     // Restrict the kinds of entities that are allowed to be uploaded to Grafana
     const allowedKinds = config.getStringArray('grafanaCloudCatalogInfo.allow');
 


### PR DESCRIPTION
## Summary
Fixes #16 — Backend crashes at startup if `grafanaCloudCatalogInfo` config block is missing.

## Problem
When the plugin is installed but the config block is absent (common in local development), the constructor calls `config.getStringArray('grafanaCloudCatalogInfo.allow')` which throws immediately, crashing the entire Backstage backend.

## Fix
Check `config.has('grafanaCloudCatalogInfo')` before reading any config values. If absent, the processor disables itself with an info log and returns — no crash, no errors.

## Context
After installing the plugin, local developers without the config block in their `app-config.local.yaml` couldn't start Backstage. The plugin had to be reverted because of this + a separate TLS issue.

## Testing
- Without config: processor logs 'No grafanaCloudCatalogInfo config found. Disabled.' and backend starts normally
- With config + `enable: false`: existing behavior unchanged
- With config + `enable: true`: existing behavior unchanged