### PR TITLE
fix: add exponential backoff on connection failure

### DIFF
--- a/src/processor.ts
+++ b/src/processor.ts
@@ -67,6 +67,8 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
   lastConnectionAttempt: Date | undefined = undefined;
   // Lock to prevent multiple simultaneous connection attempts
   private isConnecting: boolean = false;
+  // Number of consecutive connection failures (for backoff)
+  private consecutiveFailures: number = 0;
 
   // The version of the ServiceModel API we are using
   serviceModelVersion: string = '';
@@ -159,19 +161,6 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
           this.logger.debug(
             'GrafanaServiceModelProcessor: Trying to get connection to Grafana Cloud.',
           );
-
-          const now = new Date();
-          if (
-            this.lastConnectionAttempt !== undefined &&
-            now.getTime() - this.lastConnectionAttempt.getTime() < 1000
-          ) {
-            this.logger.debug(
-              'GrafanaServiceModelProcessor: Trying to get connection to Grafana Cloud too soon after last attempt.',
-            );
-            resolve(false);
-            return;
-          }
-          this.lastConnectionAttempt = now;
 
           try {
             // Get the Grafana Cloud K8s Config using configured Cloud Access Policies
@@ -288,9 +277,39 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         resolve(entity);
         return;
       } else if (!this.grafanaAvailable) {
+        // Exponential backoff: don't retry if we failed recently
+        // Sequence: 1min, 2min, 4min, 8min, ... up to 1hr max
+        const now = new Date();
+        const backoffMs = Math.min(
+          60000 * Math.pow(2, Math.max(0, this.consecutiveFailures - 1)),
+          3600000,
+        ); // max 1hr
+        if (
+          this.lastConnectionAttempt &&
+          now.getTime() - this.lastConnectionAttempt.getTime() < backoffMs
+        ) {
+          resolve(entity);
+          return;
+        }
+
+        this.lastConnectionAttempt = now;
         await this.createAndTestGrafanaConnection().then(result => {
           this.grafanaAvailable = result;
-          // Catch you next time
+          if (result) {
+            this.consecutiveFailures = 0;
+            this.logger.info(
+              'GrafanaServiceModelProcessor: Connection restored.',
+            );
+          } else {
+            this.consecutiveFailures++;
+            const nextBackoffSec = Math.min(
+              60 * Math.pow(2, Math.max(0, this.consecutiveFailures - 1)),
+              3600,
+            );
+            this.logger.warn(
+              `GrafanaServiceModelProcessor: Connection failed (attempt ${this.consecutiveFailures}). Next retry in ${nextBackoffSec}s.`,
+            );
+          }
           resolve(entity);
           return;
         });


### PR DESCRIPTION
## Summary
Fixes #161 — Plugin spams errors with no backoff when connection to Grafana fails.

## Problem
When the plugin cannot connect to Grafana (TLS error, network issue, wrong token), it retries on **every entity** processed in **every catalog cycle**. In a large catalog (~5000 services), this generates **millions of errors in days** and burns through error budgets, forcing a revert.

## Fix
Adds exponential backoff on connection failures:
- After failure: waits 1min before next retry
- Each consecutive failure doubles the wait: 1min, 2min, 4min, 8min... up to 1hr max
- Logs every failed attempt with count and next retry time
- Logs when connection is restored
- Resets backoff on successful connection
- Removed conflicting 1-second cooldown inside createAndTestGrafanaConnection (outer backoff now handles all rate-limiting)

## Before
```
Entity 1: GrafanaServiceModelProcessor: k8s not available. Error: ...
Entity 2: GrafanaServiceModelProcessor: k8s not available. Error: ...
... (thousands of times per cycle)
```

## After
```
GrafanaServiceModelProcessor: Connection failed (attempt 1). Next retry in 60s.
(silence until next retry window)
```

## Impact
- Reduces error volume from millions to single digits per hour when connection is down
- Preserves error budgets
- No impact on happy path (backoff resets on success)