### PR TITLE
fix: await API call before caching to prevent silent data loss

### DIFF
--- a/src/processor.ts
+++ b/src/processor.ts
@@ -312,7 +312,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         );
 
         const CACHE_KEY = stringifyEntityRef(entity);
-        cache.get(CACHE_KEY).then(cachedEntity => {
+        cache.get(CACHE_KEY).then(async cachedEntity => {
           if (!cachedEntity) {
             this.logger.debug(
               `GrafanaServiceModelProcessor.postProcessEntity entity '${entity.kind}' with name '${entity.metadata.name}' not found in cache`,
@@ -324,45 +324,51 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
           }
 
           if (!cachedEntity || !_.isEqual(entity, cachedEntity)) {
-            this.createOrUpdateModel(entity)
-              .then(async result => {
-                if (result) {
-                  // Update the cache if we were successful in storing the model
-                  cache.set(CACHE_KEY, entity);
-                  // resolve(entity);
-                  // return;
-                }
-              })
-              .catch((err: any) => {
-                this.logger.error(
-                  `GrafanaServiceModelProcessor.postProcessEntity error: ${
-                    err.message || 'Unknown error'
-                  }`,
-                  {
-                    error: {
-                      name: err.name,
-                      message: err.message,
-                      stack: err.stack,
-                      ...(err instanceof Error ? {} : { details: err }),
-                    },
-                    entity: {
-                      kind: entity.kind,
-                      metadata: {
-                        name: entity.metadata.name,
-                        namespace: entity.metadata.namespace,
-                      },
+            try {
+              await this.createOrUpdateModel(entity);
+              // Cache on any successful API outcome (true = created/updated,
+              // false = already matches). Both mean entity is in sync.
+              try {
+                await cache.set(CACHE_KEY, entity);
+              } catch (cacheWriteErr: any) {
+                this.logger.warn(
+                  `GrafanaServiceModelProcessor: cache.set failed after successful API write for ${CACHE_KEY}: ${cacheWriteErr?.message}`,
+                );
+                // Acceptable: next cycle will re-call API (idempotent) but entity IS synced
+              }
+            } catch (err: any) {
+              this.logger.error(
+                `GrafanaServiceModelProcessor.postProcessEntity error: ${
+                  err.message || 'Unknown error'
+                }`,
+                {
+                  error: {
+                    name: err.name,
+                    message: err.message,
+                    stack: err.stack,
+                    ...(err instanceof Error ? {} : { details: err }),
+                  },
+                  entity: {
+                    kind: entity.kind,
+                    metadata: {
+                      name: entity.metadata.name,
+                      namespace: entity.metadata.namespace,
                     },
                   },
-                );
-                // Eat the error, we don't want to stop the catalog from processing
-                // don't cache the entity, we will want to procees it again.
-              });
+                },
+              );
+              // Don't cache — entity will be retried on next cycle
+            }
+          } else {
+            // Entity unchanged, refresh cache TTL
+            await cache.set(CACHE_KEY, entity);
           }
-          // The cache is ephemeral between invocations, so we need to add the entity to the cache
-          // on every invocation.
-          cache.set(CACHE_KEY, entity);
           resolve(entity);
-          return;
+        }).catch((cacheErr: any) => {
+          this.logger.warn(
+            `GrafanaServiceModelProcessor: cache.get failed for ${CACHE_KEY}: ${cacheErr?.message}`,
+          );
+          resolve(entity);
         });
       }
     });


### PR DESCRIPTION
## Summary
Fixes the most critical bug in the plugin: failed API calls are cached as successful, causing silent permanent data loss.

## Problem
`createOrUpdateModel` was called fire-and-forget (not awaited). `cache.set` at line 384 ran immediately BEFORE the API call returned. Any failure (429, 500, 409, timeout) resulted in the entity being cached as 'synced' — it would **never be retried** until the entity changed in Backstage.

In a catalog with 5000 services, if Grafana returned a single 500 burst, those entities would be permanently out of sync.

## Fix
1. **Await the API call** before deciding to cache — failed entities are NOT cached, ensuring retry on next cycle
2. **Only cache on success** — `cache.set` moves inside the success path
3. **Add `.catch()` on `cache.get`** — prevents zombie entities that hang forever if cache backend fails

## Before
```
Entity synced to Grafana? UNKNOWN (fire-and-forget)
Cached as synced? YES (always, immediately)
Will retry on failure? NO (cached = done)
```

## After
```
Entity synced to Grafana? YES → cache it
Entity synced to Grafana? NO → don't cache → retry next cycle
cache.get fails? → log warning, continue, don't crash
```

## Impact
- Eliminates silent data loss on transient Grafana failures
- Entities will self-heal on next catalog cycle after Grafana recovers
- No behavior change on happy path (success still caches normally)