### PR TITLE
fix(ci): restore npm publishing (OIDC exchange + stage-only publisher)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,11 +90,12 @@ jobs:
       # with a misleading E404/ENEEDAUTH. Do not re-add it.
       # See https://github.com/actions/setup-node/issues/1551 and https://github.com/npm/cli/issues/9088
       #
-      # Node is pinned to 22 rather than .nvmrc (20) because npm trusted publishing
-      # requires Node >= 22.14.0.
+      # Node is pinned to 24 (current LTS) rather than .nvmrc (20): npm trusted
+      # publishing requires Node >= 22.14.0, and npm@latest (12.x) requires
+      # ^22.22.2 || ^24.15.0 || >=26.
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 # zizmor: ignore[cache-poisoning] Mitigated by pre-publish validation
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -112,8 +113,8 @@ jobs:
         run: |
           set -euo pipefail
           echo "node $(node --version) / npm $(npm --version)"
-          npx --yes semver -r '>=11.5.1' "$(npm --version)" >/dev/null \
-            || { echo "::error::npm $(npm --version) is too old for trusted publishing (need >=11.5.1)"; exit 1; }
+          npx --yes semver -r '>=11.15.0' "$(npm --version)" >/dev/null \
+            || { echo "::error::npm $(npm --version) is too old (need >=11.15.0 for trusted publishing and the 'stage' command)"; exit 1; }
           if npm config get userconfig >/dev/null 2>&1; then
             npmrc="$(npm config get userconfig)"
             if [ -f "$npmrc" ] && grep -q '_authToken' "$npmrc"; then
@@ -122,8 +123,36 @@ jobs:
             fi
           fi
 
-      - name: Publish to NPM
-        run: npm publish --access public
+      # The npm trusted publisher for this package is configured stage-only: it
+      # permits `npm stage publish` but NOT `npm publish`. Staging uploads the
+      # tarball in a non-public state; a maintainer must then approve it with a
+      # 2FA challenge before it becomes installable. This means a compromised CI
+      # run cannot ship a public release on its own.
+      #
+      # To complete a release after this job succeeds:
+      #   npm stage list @grafana/catalog-backend-module-grafana-servicemodel
+      #   npm stage view <stage-id>       # optional: inspect before approving
+      #   npm stage approve <stage-id>    # prompts for 2FA
+      #
+      # Changing this back to plain `npm publish` will fail until the trusted
+      # publisher on npmjs.com is edited to allow the `npm publish` action.
+      - name: Stage publish to NPM
+        run: npm stage publish --access public
+
+      - name: Summarize approval step
+        run: |
+          {
+            echo "### Package staged, not yet public"
+            echo ""
+            echo "\`${GITHUB_REF_NAME}\` was staged to npm but is **not installable** until approved with 2FA:"
+            echo ""
+            echo '```'
+            echo "npm stage list @grafana/catalog-backend-module-grafana-servicemodel"
+            echo "npm stage approve <stage-id>"
+            echo '```'
+            echo ""
+            echo "Or approve via the Staged Packages tab on npmjs.com."
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Create GitHub Release
         uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,10 +83,18 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 # zizmor: ignore[cache-poisoning] Mitigated by immutable lockfile and pre-publish validation
+      # NOTE: `registry-url` is deliberately NOT set here. It makes setup-node write
+      # `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into an .npmrc. With no
+      # NODE_AUTH_TOKEN (we authenticate via OIDC), that expands to an empty token, npm
+      # treats auth as already configured, never performs the OIDC exchange, and fails
+      # with a misleading E404/ENEEDAUTH. Do not re-add it.
+      # See https://github.com/actions/setup-node/issues/1551 and https://github.com/npm/cli/issues/9088
+      #
+      # Node is pinned to 22 rather than .nvmrc (20) because npm trusted publishing
+      # requires Node >= 22.14.0.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0 # zizmor: ignore[cache-poisoning] Mitigated by pre-publish validation
         with:
-          node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: '22'
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -96,6 +104,23 @@ jobs:
 
       - name: Update npm for trusted publishing
         run: npm install -g npm@latest
+
+      # Guards against silent regressions of the two failure modes that broke
+      # releases v0.3.29 through v0.3.39. Fails loudly and early instead of
+      # surfacing as a misleading E404 from `npm publish`.
+      - name: Verify trusted publishing preconditions
+        run: |
+          set -euo pipefail
+          echo "node $(node --version) / npm $(npm --version)"
+          npx --yes semver -r '>=11.5.1' "$(npm --version)" >/dev/null \
+            || { echo "::error::npm $(npm --version) is too old for trusted publishing (need >=11.5.1)"; exit 1; }
+          if npm config get userconfig >/dev/null 2>&1; then
+            npmrc="$(npm config get userconfig)"
+            if [ -f "$npmrc" ] && grep -q '_authToken' "$npmrc"; then
+              echo "::error::_authToken found in $npmrc -- this suppresses the OIDC exchange. Did someone re-add registry-url to setup-node?"
+              exit 1
+            fi
+          fi
 
       - name: Publish to NPM
         run: npm publish --access public

--- a/docs/release.md
+++ b/docs/release.md
@@ -28,10 +28,49 @@ The GitHub Actions workflow will automatically:
 1. Run lint checks
 2. Run unit tests
 3. Run integration tests
-4. Publish to NPM
+4. **Stage** the package on NPM (not yet public — see below)
 5. Create a GitHub release with generated release notes
 
 You can monitor the release progress at:
 https://github.com/grafana/backstage-plugin-grafana-catalog/actions
 
-Note: You'll need appropriate permissions to push to the repository and publish to NPM.
+## Step 4: Approve the staged package
+
+**The release is not complete when the workflow goes green.** CI does not have
+permission to publish publicly — it can only stage.
+
+We authenticate to NPM with [trusted publishing][tp]: GitHub Actions mints a
+short-lived OIDC token instead of using a stored NPM token. The trusted
+publisher is deliberately configured **stage-only**, so a compromised CI run
+cannot ship a public release by itself. A maintainer must approve each version
+with a 2FA challenge.
+
+After the workflow succeeds:
+
+```bash
+npm stage list @grafana/catalog-backend-module-grafana-servicemodel
+npm stage view <stage-id>       # optional: inspect the tarball first
+npm stage approve <stage-id>    # prompts for 2FA
+```
+
+Or use the **Staged Packages** tab on npmjs.com.
+
+Requires npm >= 11.15.0 and 2FA enabled on your npm account.
+
+## Troubleshooting
+
+**Publish job fails with a 404 or `ENEEDAUTH`.** These errors are misleading;
+they usually mean the OIDC exchange never happened. Check that nobody re-added
+`registry-url` to `actions/setup-node` in the publish job — it writes an empty
+`_authToken` into `.npmrc`, which makes npm think auth is already configured and
+skip OIDC entirely. This silently broke every release from v0.3.29 to v0.3.39.
+The `Verify trusted publishing preconditions` step now catches this.
+
+**Publish job fails claiming the action is not permitted.** The trusted
+publisher's allowed actions on npmjs.com must match the command the workflow
+runs. It currently allows `npm stage publish` only.
+
+Note: You'll need appropriate permissions to push to the repository, and to be a
+maintainer on the NPM package to approve staged releases.
+
+[tp]: https://docs.npmjs.com/trusted-publishers/


### PR DESCRIPTION
## Summary

npm releases have been silently broken since **January 2026**. The last version actually on npm is **0.3.28** — tags `v0.3.39` through `v0.3.29` (11 of them) all failed in the Publish job while lint, tests, and integration passed. `package.json` says `0.3.39`; npm's `latest` says `0.3.28`.

This fixes **two independent root causes**. Either one alone would block publishing.

## Root cause 1 — the OIDC exchange never happened

`7c25738` removed `NODE_AUTH_TOKEN` to move to trusted publishing, but left `registry-url` on `actions/setup-node`. That makes setup-node write:

```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```

With no `NODE_AUTH_TOKEN`, this expands to an **empty** token. npm sees auth as already configured, never performs the OIDC token exchange, and fails with a misleading `E404`. This is a known interaction — actions/setup-node#1551, npm/cli#9088.

The timing matches exactly: failures begin with the commit that removed the token but kept `registry-url`.

**Fix:** drop `registry-url` (npmjs.org is the default registry anyway), with a comment explaining why it must not come back.

## Root cause 2 — the workflow ran a command the publisher doesn't permit

The trusted publisher registered on npmjs.com is configured **stage-only**: it allows `npm stage publish` but *not* `npm publish`. The workflow ran `npm publish`, so it would have been rejected even with root cause 1 fixed.

[Staged publishing](https://docs.npmjs.com/staged-publishing/) went GA on 2026-05-22 — months after the January failures — so this is a newer, second blocker rather than the original one.

**Fix:** switch to `npm stage publish --access public` rather than loosening the npm-side config. Keeping the publisher stage-only means a compromised CI run cannot ship a public release on its own; a maintainer approves each version with a 2FA challenge.

## Also in this PR

- **Precondition guard** that fails with a clear `::error::` if npm is below 11.15.0 or if an `_authToken` reappears in the npmrc. The original failure cost 11 tags and surfaced as a bare `E404`, and the run logs have since expired (HTTP 410) — so nobody could go back and diagnose it. This makes the next regression legible.
- **Node 24** for the publish job (`.nvmrc` stays at 20 for lint/test/integration). Trusted publishing needs >= 22.14.0, and `npm@latest` is now 12.x requiring `^22.22.2 || ^24.15.0 || >=26`; Node 22 only clears that at 22.23.1.
- **Job summary** telling the maintainer how to approve the staged package.
- **`docs/release.md`** documents the approval step and both failure modes.
- Corrected a `zizmor` suppression rationale that credited an "immutable lockfile" — see below.

## Version floors were verified, not assumed

`npm stage` is **absent** from npm 11.12.1 and **present** in 11.15.0, checked against the published tarballs. 11.15.0 is therefore the real floor, which also matches the threshold in the internal npm supply-chain audit skill.

## Unrelated finding, not fixed here

Both workflows run `yarn install --immutable`. That is a **Yarn 2+ flag**; this repo pins `yarn@1.22.22`, which does not have it. Verified directly:

```
$ npx yarn@1.22.22 install --immutable
success Saved lockfile.
```

It silently ignores the flag and *writes* the lockfile. Every "immutable lockfile" guarantee in CI is currently a no-op — including the stated justification for the `zizmor: ignore[cache-poisoning]` suppression, which this PR trims accordingly. The yarn 1 equivalent is `--frozen-lockfile`.

A broader supply-chain audit also found the pinned yarn 1 supports none of `enableScripts: false`, `approvedGitRepositories`, or `npmMinimalAgeGate`. The release-age gate is worth real money given this repo's Renovate volume. That's a lockfile-format migration touching the same workflow file, so it's deliberately kept out of this PR.

## Testing

- YAML parses; `zizmor` reports no new findings (the one informational hit about `action-gh-release` predates this branch).
- **Not end-to-end tested.** `npm stage publish` under OIDC only runs in CI on a tag push, so the first real release is the test. The precondition step exists so a failure is legible rather than another bare `E404`.

## Releasing after this merges

The workflow going green **no longer means the release shipped**:

```bash
npm stage list @grafana/catalog-backend-module-grafana-servicemodel
npm stage approve <stage-id>    # prompts for 2FA — this is what ships it
```

Next release will be `v0.3.40`; `0.3.29`–`0.3.39` remain permanently absent from npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
