### PR TITLE
fix: correct repository.url and make releases work from protected main

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -1,27 +1,42 @@
 # Release Process
 
-The release process is automated using GitHub Actions. To create a new release:
+Releases are cut from `main` in **two steps**. `main` is protected by a
+`pull_request` ruleset, so the version bump cannot be pushed directly — it has
+to go through a PR. Only then is the merged commit tagged.
 
-1. Ensure you're on the branch you want to release from and all changes are committed.
+## Step 1: open the version bump PR
 
-2. Run the release script:
+From an up-to-date `main` with a clean working tree:
 
-   ```bash
-   ./scripts/release.sh
-   ```
+```bash
+git checkout main && git pull
+./scripts/release.sh
+```
 
-3. Follow the prompts to select the version type:
-   - patch: for bug fixes (0.0.X)
-   - minor: for new features (0.X.0)
-   - major: for breaking changes (X.0.0)
+Follow the prompts to select the version type:
 
-The script will:
+- patch: for bug fixes (0.0.X)
+- minor: for new features (0.X.0)
+- major: for breaking changes (X.0.0)
 
-- Verify your working directory is clean
-- Ensure you're up to date with the remote
-- Update the version in package.json
-- Create and push a git tag
-- Push the changes
+This bumps the version in `package.json`, pushes a `release/vX.Y.Z` branch, and
+opens a PR. It does **not** create a tag.
+
+## Step 2: tag the merged commit
+
+Once that PR is merged:
+
+```bash
+git checkout main && git pull
+./scripts/release.sh --tag
+```
+
+This tags the merged commit on `main` and pushes the tag, which triggers the
+Release workflow.
+
+The script refuses to run from any branch other than `main`. Tagging from a
+feature branch produces a tag that is not an ancestor of `main` — that is how
+`v0.3.40` ended up orphaned.
 
 The GitHub Actions workflow will automatically:
 
@@ -69,6 +84,13 @@ The `Verify trusted publishing preconditions` step now catches this.
 **Publish job fails claiming the action is not permitted.** The trusted
 publisher's allowed actions on npmjs.com must match the command the workflow
 runs. It currently allows `npm stage publish` only.
+
+**`E422 ... Error verifying sigstore provenance bundle`.** npm cross-checks
+`repository.url` in `package.json` against the repository recorded in the
+provenance attestation, and rejects the upload if they disagree. Keep
+`repository.url` pointed at `github.com/grafana/backstage-plugin-grafana-catalog`
+in a form `hosted-git-info` can parse — a bare `github.com/...` string with no
+scheme normalizes to `null` and will fail this check.
 
 Note: You'll need appropriate permissions to push to the repository, and to be a
 maintainer on the NPM package to approve staged releases.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@grafana/catalog-backend-module-grafana-servicemodel",
   "description": "The grafana-service-model backend module for the catalog plugin.",
-  "homepage": "https://github.com/grafana/catalog-backend-module-grafana-servicemodel",
+  "homepage": "https://github.com/grafana/backstage-plugin-grafana-catalog",
   "version": "0.3.39",
   "main": "src/index.ts",
   "types": "src/index.ts",
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "github.com/grafana/catalog-backend-module-grafana-servicemodel"
+    "url": "git+https://github.com/grafana/backstage-plugin-grafana-catalog.git"
   },
   "keywords": [
     "backstage",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,64 +1,133 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# Ensure we're in a clean state
+# Two-step release, because `main` is protected by a `pull_request` ruleset:
+# direct pushes are rejected, so the version bump has to go through a PR.
+#
+#   Step 1 (default):  ./scripts/release.sh
+#                      Bumps the version on a release branch and opens a PR.
+#
+#   Step 2 (--tag):    ./scripts/release.sh --tag
+#                      Run after the PR merges. Tags the merged commit on main
+#                      and pushes the tag, which triggers the Release workflow.
+#
+# Previously this script pushed straight to the current branch. Run from a
+# feature branch it silently produced a tag that was not an ancestor of main
+# (see v0.3.40); run from main the push would simply have been rejected.
+
+usage() {
+  echo "Usage: $0 [--tag]"
+  echo "  (no args)  bump the version on a release branch and open a PR"
+  echo "  --tag      after that PR merges, tag main and push to trigger the release"
+  exit 1
+}
+
+MODE="bump"
+case "${1:-}" in
+  --tag) MODE="tag" ;;
+  "")    MODE="bump" ;;
+  *)     usage ;;
+esac
+
 if [[ -n $(git status --porcelain) ]]; then
   echo "Error: Working directory is not clean. Please commit or stash changes first."
   exit 1
 fi
 
-# Ensure we have the latest changes
 echo "Fetching latest changes..."
-git fetch origin
+git fetch origin --tags --quiet
 
-# Get the current branch
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-
-# Ensure we're up to date with origin
-if [[ -n $(git rev-list HEAD...origin/$BRANCH) ]]; then
-  echo "Error: Local branch is not up to date with origin. Please pull latest changes."
+if [[ "$BRANCH" != "main" ]]; then
+  echo "Error: releases must be cut from 'main' (currently on '$BRANCH')."
+  echo "       Tagging from another branch produces a tag that is not an ancestor of main."
   exit 1
 fi
 
-# Prompt for version type
+if [[ -n $(git rev-list HEAD...origin/main) ]]; then
+  echo "Error: local main is not in sync with origin/main. Please pull latest changes."
+  exit 1
+fi
+
+# ---------------------------------------------------------------- step 2: tag
+if [[ "$MODE" == "tag" ]]; then
+  VERSION=$(node -p "require('./package.json').version")
+  TAG="v$VERSION"
+
+  if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+    echo "Error: tag $TAG already exists locally. Delete it first if it is stale:"
+    echo "         git tag -d $TAG && git push origin :refs/tags/$TAG"
+    exit 1
+  fi
+  if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+    echo "Error: tag $TAG already exists on origin. Delete it first if it is stale:"
+    echo "         git push origin :refs/tags/$TAG"
+    exit 1
+  fi
+
+  echo "Tagging $(git rev-parse --short HEAD) on main as $TAG"
+  git tag -a "$TAG" -m "$VERSION"
+  git push origin "$TAG"
+
+  echo ""
+  echo "Release workflow triggered for $TAG."
+  echo "Monitor: https://github.com/grafana/backstage-plugin-grafana-catalog/actions"
+  echo ""
+  echo "IMPORTANT: a green workflow does NOT mean the release shipped. The package"
+  echo "is staged on npm and must be approved with 2FA:"
+  echo "  npm stage list @grafana/catalog-backend-module-grafana-servicemodel"
+  echo "  npm stage approve <stage-id>"
+  exit 0
+fi
+
+# --------------------------------------------------------------- step 1: bump
 echo "Select version type:"
 echo "1) patch (bug fixes)"
 echo "2) minor (new features)"
 echo "3) major (breaking changes)"
-read -p "Enter choice (1-3): " VERSION_TYPE
+read -r -p "Enter choice (1-3): " VERSION_TYPE
 
 case $VERSION_TYPE in
-  1)
-    VERSION_ARG="patch"
-    ;;
-  2)
-    VERSION_ARG="minor"
-    ;;
-  3)
-    VERSION_ARG="major"
-    ;;
-  *)
-    echo "Invalid choice"
-    exit 1
-    ;;
+  1) VERSION_ARG="patch" ;;
+  2) VERSION_ARG="minor" ;;
+  3) VERSION_ARG="major" ;;
+  *) echo "Invalid choice"; exit 1 ;;
 esac
 
-# Update version
-echo "Updating version..."
-NEW_VERSION=$(npm version $VERSION_ARG)
+# --no-git-tag-version: the tag is created in step 2, against the merged commit
+# on main, not against this branch.
+NEW_VERSION=$(npm version "$VERSION_ARG" --no-git-tag-version)
+NEW_VERSION=${NEW_VERSION#v}
+RELEASE_BRANCH="release/v$NEW_VERSION"
 
-# Push changes and tags
-echo "Pushing changes and tags..."
-git push origin $BRANCH
-git push origin $NEW_VERSION
+echo "Preparing $RELEASE_BRANCH ..."
+git checkout -b "$RELEASE_BRANCH"
+git add package.json
+git commit -m "chore(release): v$NEW_VERSION"
+git push -u origin "$RELEASE_BRANCH"
 
-echo "Release process initiated!"
-echo "New version: $NEW_VERSION"
-echo "GitHub Actions will now:"
-echo "1. Run lint checks"
-echo "2. Run unit tests"
-echo "3. Run integration tests"
-echo "4. Publish to NPM"
-echo "5. Create a GitHub release"
+if command -v gh >/dev/null 2>&1; then
+  gh pr create \
+    --base main \
+    --head "$RELEASE_BRANCH" \
+    --title "chore(release): v$NEW_VERSION" \
+    --body "Version bump to \`v$NEW_VERSION\`.
+
+After merging, run:
+
+\`\`\`bash
+git checkout main && git pull
+./scripts/release.sh --tag
+\`\`\`
+
+That tags the merged commit and triggers the Release workflow, which **stages**
+the package on npm. It is not public until approved with 2FA."
+else
+  echo "gh CLI not found - open a PR for $RELEASE_BRANCH manually."
+fi
+
 echo ""
-echo "Monitor the progress at: https://github.com/grafana/backstage-plugin-grafana-catalog/actions"
+echo "Next steps:"
+echo "  1. Get the PR reviewed and merged."
+echo "  2. git checkout main && git pull"
+echo "  3. ./scripts/release.sh --tag"


### PR DESCRIPTION
## Summary

Cutting `v0.3.40` surfaced two more problems. The good news first: **trusted publishing now works.** The run got all the way to signing provenance —

```
npm notice stage Signed provenance statement with source and build information from GitHub Actions
npm notice stage Provenance statement published to transparency log: logIndex=2275786652
```

— which confirms the OIDC and stage-only fixes from #168 are correct. What follows are two distinct problems behind them.

## 1. `repository.url` pointed at a repository that doesn't exist

```
npm error code E422
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "github.com/grafana/catalog-backend-module-grafana-servicemodel",
expected to match "https://github.com/grafana/backstage-plugin-grafana-catalog" from provenance
```

npm cross-checks `repository.url` against the repo recorded in the provenance attestation. Ours named `catalog-backend-module-grafana-servicemodel` — the *package* name, not the repo — and had no URL scheme, so `hosted-git-info` normalizes it to `null`.

This has been wrong for the life of the package. It only surfaces now because provenance is being generated for the first time; versions through `0.3.28` carry no attestations, so nothing ever validated it. `homepage` pointed at the same non-existent repo.

Verified the fix normalizes to exactly what provenance expects:

```
git+https://github.com/grafana/backstage-plugin-grafana-catalog.git
  -> https://github.com/grafana/backstage-plugin-grafana-catalog   MATCH
github.com/grafana/catalog-backend-module-grafana-servicemodel
  -> null                                                          NOMATCH
```

## 2. `release.sh` cannot work from `main`

`main` carries a `pull_request` ruleset:

```
main:  ["deletion","non_fast_forward","pull_request","repository_visibility","required_signatures","workflows"]
```

`release.sh` ran `git push origin $BRANCH`. From `main` that push is **rejected**. The script had no branch guard, so running it from a feature branch tagged *that branch* instead — which is how `v0.3.40` came to point at a commit that is not an ancestor of `main`.

The script is now two steps:

```bash
./scripts/release.sh          # bumps version on release/vX.Y.Z, opens a PR
# ... PR merges ...
./scripts/release.sh --tag    # tags the merged commit on main, triggers release
```

It refuses to run from any branch but `main`, and refuses to reuse an existing tag (local or remote) rather than silently doing the wrong thing.

`docs/release.md` documents both steps plus the E422 failure mode.

## Follow-up not in this PR

The orphaned `v0.3.40` tag still needs deleting — nothing was published under it and no GitHub Release was created, so it's safe to remove, but that's a separate destructive action.

## Testing

- `bash -n` and `shellcheck` clean on `release.sh`
- Branch guard verified to refuse in both modes from a non-`main` branch
- `package.json` validates as JSON
- URL normalization verified against `hosted-git-info` rather than assumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
