### PR TITLE
fix(ci): grant contents:write so the release step can create a GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
   publish:
     name: Publish
     permissions:
-      contents: read
+      contents: write  # Required by the Create GitHub Release step below
       pull-requests: write
       id-token: write  # Required for npm OIDC trusted publishing
     environment: npm-publish # Required for npm OIDC trusted publishing


### PR DESCRIPTION
The `v0.3.40` run **staged to npm successfully** — trusted publishing, provenance, and the stage-only grant all worked:

```
+ @grafana/catalog-backend-module-grafana-servicemodel@0.3.40 (staged with id bb4eba74-…)
npm notice stage Provenance statement published to transparency log: logIndex=2276551992
```

It then failed on the final step:

```
⚠️ GitHub release failed with status: 403
{"message":"Resource not accessible by integration"}
```

The publish job grants `contents: read`; creating a release needs `contents: write`.

Like the `repository.url` mismatch in #169, this was latent for as long as the step has existed — no run had ever reached it, because publishing failed first on every release since `v0.3.29`.

**The npm side of `v0.3.40` is unaffected.** The package is staged and awaiting 2FA approval; this only fixes the GitHub Release object for subsequent releases.

## Testing

YAML validates; `zizmor` reports no new findings (the single informational hit about `action-gh-release` predates this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)