### PR TITLE
fix: integrate reliability PRs #162-#165, and only cache successful uploads

### DIFF
--- a/src/kube_config.test.ts
+++ b/src/kube_config.test.ts
@@ -1,0 +1,193 @@
+import { EventEmitter } from 'events';
+import https from 'https';
+import { LoggerService } from '@backstage/backend-plugin-api';
+
+import { getGrafanaConnectionInfo, getIdFromSlug } from './kube_config';
+
+const ENDPOINT = 'https://grafana-dev.com';
+const SLUG = 'dev';
+const TOKEN = 'a-token';
+
+type Outcome =
+  | { body: string }
+  | { timeout: true }
+  | { networkError: NodeJS.ErrnoException };
+
+describe('GCOM requests', () => {
+  let logger: jest.Mocked<LoggerService>;
+  let destroyed: Error[];
+  let requests: Array<{ url: string; options: any }>;
+
+  beforeEach(() => {
+    logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn(),
+    } as unknown as jest.Mocked<LoggerService>;
+
+    destroyed = [];
+    requests = [];
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // Stand in for https.get, driving whichever outcome the test asks for.
+  function mockHttpsGet(outcome: Outcome) {
+    return jest.spyOn(https, 'get').mockImplementation(((
+      url: any,
+      options: any,
+      callback: any,
+    ) => {
+      requests.push({ url: String(url), options });
+
+      const req: any = new EventEmitter();
+      req.destroy = (error?: Error) => {
+        if (error) {
+          destroyed.push(error);
+          req.emit('error', error);
+        }
+      };
+
+      // Let the caller attach its 'timeout' and 'error' handlers first.
+      setImmediate(() => {
+        if ('timeout' in outcome) {
+          req.emit('timeout');
+        } else if ('networkError' in outcome) {
+          req.emit('error', outcome.networkError);
+        } else {
+          const res = new EventEmitter();
+          callback(res);
+          res.emit('data', outcome.body);
+          res.emit('end');
+        }
+      });
+
+      return req;
+    }) as any);
+  }
+
+  describe('getIdFromSlug', () => {
+    it('resolves the stack id', async () => {
+      mockHttpsGet({ body: JSON.stringify({ id: 42 }) });
+
+      await expect(getIdFromSlug(logger, ENDPOINT, SLUG, TOKEN)).resolves.toBe(
+        42,
+      );
+      expect(requests[0].url).toBe('https://grafana-dev.com/api/instances/dev');
+    });
+
+    it('sends the bearer token and a 30s timeout', async () => {
+      mockHttpsGet({ body: JSON.stringify({ id: 42 }) });
+
+      await getIdFromSlug(logger, ENDPOINT, SLUG, TOKEN);
+
+      expect(requests[0].options).toMatchObject({
+        headers: { Authorization: `Bearer ${TOKEN}` },
+        timeout: 30_000,
+      });
+    });
+  });
+
+  describe('getGrafanaConnectionInfo', () => {
+    const connectionsBody = JSON.stringify({
+      appPlatform: { caData: 'a-ca-cert', url: 'https://apiserver' },
+    });
+
+    it('resolves the connection info', async () => {
+      mockHttpsGet({ body: connectionsBody });
+
+      await expect(
+        getGrafanaConnectionInfo(logger, ENDPOINT, SLUG, TOKEN),
+      ).resolves.toEqual({
+        caData: 'a-ca-cert',
+        url: 'https://apiserver',
+        token: TOKEN,
+      });
+      expect(requests[0].url).toBe(
+        'https://grafana-dev.com/api/instances/dev/connections',
+      );
+    });
+
+    it('rejects when the token is not accepted', async () => {
+      mockHttpsGet({ body: JSON.stringify({ code: 'InvalidCredentials' }) });
+
+      await expect(
+        getGrafanaConnectionInfo(logger, ENDPOINT, SLUG, TOKEN),
+      ).rejects.toThrow(/Invalid credentials/);
+    });
+
+    it('rejects when the response has no appPlatform', async () => {
+      mockHttpsGet({ body: JSON.stringify({ somethingElse: true }) });
+
+      await expect(
+        getGrafanaConnectionInfo(logger, ENDPOINT, SLUG, TOKEN),
+      ).rejects.toThrow(/No appPlatform object found/);
+    });
+  });
+
+  describe('failure handling', () => {
+    it('aborts and rejects when the request times out', async () => {
+      mockHttpsGet({ timeout: true });
+
+      await expect(
+        getIdFromSlug(logger, ENDPOINT, SLUG, TOKEN),
+      ).rejects.toThrow(/timed out after 30s/);
+
+      // A 'timeout' event leaves the socket open on its own, so the request has
+      // to be destroyed for the promise to settle at all.
+      expect(destroyed).toHaveLength(1);
+      expect(destroyed[0].message).toMatch(/timed out after 30s/);
+    });
+
+    it('rejects on a network error', async () => {
+      mockHttpsGet({
+        networkError: Object.assign(new Error('socket hang up'), {
+          code: 'ECONNRESET',
+        }),
+      });
+
+      await expect(
+        getIdFromSlug(logger, ENDPOINT, SLUG, TOKEN),
+      ).rejects.toThrow(/socket hang up/);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('socket hang up'),
+      );
+    });
+
+    it('rejects with the url when the response is not JSON', async () => {
+      mockHttpsGet({ body: '<html>502 Bad Gateway</html>' });
+
+      await expect(
+        getIdFromSlug(logger, ENDPOINT, SLUG, TOKEN),
+      ).rejects.toThrow(
+        /Could not parse response from https:\/\/grafana-dev\.com/,
+      );
+    });
+
+    it('does not put the bearer token in the logs', async () => {
+      mockHttpsGet({
+        networkError: Object.assign(new Error('socket hang up'), {
+          code: 'ECONNRESET',
+        }),
+      });
+
+      await expect(
+        getIdFromSlug(logger, ENDPOINT, SLUG, TOKEN),
+      ).rejects.toThrow();
+
+      const logged = [
+        ...logger.error.mock.calls,
+        ...logger.warn.mock.calls,
+        ...logger.info.mock.calls,
+      ]
+        .flat()
+        .map(arg => JSON.stringify(arg))
+        .join(' ');
+      expect(logged).not.toContain(TOKEN);
+    });
+  });
+});

--- a/src/kube_config.ts
+++ b/src/kube_config.ts
@@ -21,6 +21,11 @@ export type GrafanaCloudK8sConfig = {
   namespace: string;
 };
 
+// Without a timeout, a hung TCP connection to GCOM never settles, and because
+// the processor only reconnects once the previous attempt finishes, a single
+// hung socket blocks reconnection forever.
+const HTTP_TIMEOUT_MS = 30_000;
+
 // Make connection to gcom and get the caData using the token in the config
 // Construct the kubeconfig object from the response
 export async function getGrafanaCloudK8sConfig(
@@ -121,7 +126,72 @@ export async function getGrafanaCloudK8sConfig(
   };
 }
 
-async function getIdFromSlug(
+/**
+ * getJson issues an authenticated GET against GCOM and resolves the parsed JSON
+ * body. Both GCOM calls go through here so the timeout cannot be forgotten on
+ * one of them.
+ */
+async function getJson(
+  logger: LoggerService,
+  url: string,
+  token: string,
+): Promise<any> {
+  const options = {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    timeout: HTTP_TIMEOUT_MS,
+  };
+
+  return new Promise<any>((resolve, reject) => {
+    const req = https.get(url, options, res => {
+      let data = '';
+
+      res.on('data', chunk => {
+        data += chunk;
+      });
+
+      res.on('end', () => {
+        logger.debug(
+          `GrafanaServiceModelProcessor: Got response from ${url}: ${data}`,
+        );
+        try {
+          resolve(JSON.parse(data));
+        } catch (error: any) {
+          reject(
+            new Error(
+              `GrafanaServiceModelProcessor: Could not parse response from ${url}: ${error.message}`,
+            ),
+          );
+        }
+      });
+    });
+
+    // The 'timeout' event does not abort the request on its own. Destroying it
+    // surfaces the failure through the 'error' handler below.
+    req.on('timeout', () => {
+      req.destroy(
+        new Error(
+          `GrafanaServiceModelProcessor: Request to ${url} timed out after ${
+            HTTP_TIMEOUT_MS / 1000
+          }s`,
+        ),
+      );
+    });
+
+    req.on('error', error => {
+      logger.error(
+        `GrafanaServiceModelProcessor: Error requesting ${url}: ${error.message}`,
+      );
+      reject(error);
+    });
+  });
+}
+
+// Exported for tests only, and deliberately not re-exported from index.ts.
+// getGrafanaCloudK8sConfig itself cannot be exercised under jest because of its
+// dynamic import of @kubernetes/client-node.
+export async function getIdFromSlug(
   logger: LoggerService,
   grafanaEndpoint: string,
   stackSlug: string,
@@ -130,101 +200,35 @@ async function getIdFromSlug(
   const url = `${grafanaEndpoint}/api/instances/${stackSlug}`;
   logger.debug(`Getting stack id from ${url}`);
 
-  const options = {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  };
-
-  return new Promise<string>((resolve, reject) => {
-    https
-      .get(url, options, res => {
-        let data = '';
-
-        res.on('data', chunk => {
-          data += chunk;
-        });
-
-        res.on('end', () => {
-          logger.debug(
-            `GrafanaServiceModelProcessor: Got response from ${url}: ${data}`,
-          );
-          try {
-            const json = JSON.parse(data);
-            const id = json.id;
-            resolve(id);
-          } catch (error) {
-            reject(error);
-          }
-        });
-      })
-      .on('error', error => {
-        logger.error(
-          `GrafanaServiceModelProcessor: Error getting stack id from ${url}: ${error}`,
-        );
-        reject(error);
-      });
-  });
+  const json = await getJson(logger, url, token);
+  return json.id;
 }
 
-async function getGrafanaConnectionInfo(
+// Exported for tests only, see getIdFromSlug above.
+export async function getGrafanaConnectionInfo(
   logger: LoggerService,
   grafanaEndpoint: string,
   stackSlug: string,
   token: string,
 ): Promise<GrafanaConnectionInfo> {
-  const path = `/api/instances/${stackSlug}/connections`;
-  const url = `${grafanaEndpoint}${path}`;
+  const url = `${grafanaEndpoint}/api/instances/${stackSlug}/connections`;
   logger.debug(`Getting connection info from ${url}`);
-  const options = {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
+
+  const json = await getJson(logger, url, token);
+  if (json.code === 'InvalidCredentials') {
+    throw new Error(
+      `GrafanaServiceModelProcessor: Invalid credentials for ${url}`,
+    );
+  }
+  if (json.appPlatform === undefined) {
+    throw new Error(
+      `GrafanaServiceModelProcessor: No appPlatform object found in response from ${url}`,
+    );
+  }
+
+  return {
+    caData: json.appPlatform.caData,
+    url: json.appPlatform.url,
+    token: token,
   };
-
-  return new Promise<GrafanaConnectionInfo>((resolve, reject) => {
-    https
-      .get(url, options, res => {
-        let data = '';
-
-        res.on('data', chunk => {
-          data += chunk;
-        });
-
-        res.on('end', () => {
-          logger.debug(
-            `GrafanaServiceModelProcessor: Got response from ${url}: ${data}`,
-          );
-
-          try {
-            const json = JSON.parse(data);
-            if (json.code === 'InvalidCredentials') {
-              // throw error object
-              throw new Error(
-                `GrafanaServiceModelProcessor: Invalid credentials for ${url}`,
-              );
-            }
-            if (json.appPlatform === undefined) {
-              throw new Error(
-                `GrafanaServiceModelProcessor: No appPlatform object found in response from ${url}`,
-              );
-            }
-            const connectionInfo: GrafanaConnectionInfo = {
-              caData: json.appPlatform.caData,
-              url: json.appPlatform.url,
-              token: token,
-            };
-            resolve(connectionInfo);
-          } catch (error) {
-            reject(error);
-          }
-        });
-      })
-      .on('error', error => {
-        logger.error(
-          `GrafanaServiceModelProcessor: Error getting connection info from ${url}: ${error}`,
-        );
-        reject(error);
-      });
-  });
 }

--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -6,9 +6,11 @@ import {
   CatalogProcessorCache,
   CatalogProcessorEmit,
 } from '@backstage/plugin-catalog-node';
+import { makeValidator } from '@backstage/catalog-model';
 import {
   GrafanaServiceModelProcessor,
   entityToServiceModel,
+  isValidK8sObjectName,
   KubernetesObjectWithSpec,
 } from './processor';
 
@@ -194,33 +196,76 @@ describe('config absent', () => {
   });
 });
 
-describe('entity name validation', () => {
-  const nameRegex = /^[a-z0-9][a-z0-9\-.]*[a-z0-9]$/;
-
-  it('should accept valid K8s names', () => {
-    expect(nameRegex.test('my-service')).toBe(true);
-    expect(nameRegex.test('telemetry-gateway')).toBe(true);
-    expect(nameRegex.test('sqm-ingestor-kafka')).toBe(true);
-    expect(nameRegex.test('a1')).toBe(true);
-    expect(nameRegex.test('service.name.with.dots')).toBe(true);
+describe('isValidK8sObjectName', () => {
+  it.each([
+    ['an ordinary name', 'my-service'],
+    ['dot-separated labels', 'service.name.with.dots'],
+    ['two characters', 'a1'],
+    ['a single character', 'a'],
+    ['a single digit', '7'],
+    ['a label at its 63 char limit', 'a'.repeat(63)],
+    ['several labels at their limit', `${'a'.repeat(63)}.${'b'.repeat(63)}`],
+    // 63 chars, a dot, three times over, then 61 more: 253 exactly
+    [
+      'exactly the 253 char total limit',
+      `${'a'.repeat(63)}.`.repeat(3) + 'a'.repeat(61),
+    ],
+  ])('accepts %s', (_description, name) => {
+    expect(name.length).toBeLessThanOrEqual(253);
+    expect(isValidK8sObjectName(name)).toBe(true);
   });
 
-  it('should reject invalid K8s names', () => {
-    expect(nameRegex.test('')).toBe(false);
-    expect(nameRegex.test('-starts-with-dash')).toBe(false);
-    expect(nameRegex.test('ends-with-dash-')).toBe(false);
-    expect(nameRegex.test('.starts-with-dot')).toBe(false);
-    expect(nameRegex.test('has spaces')).toBe(false);
-    expect(nameRegex.test('HAS-UPPERCASE')).toBe(false);
-    expect(nameRegex.test('../../admin')).toBe(false);
-    expect(nameRegex.test('foo/bar')).toBe(false);
-    expect(nameRegex.test('a')).toBe(false); // single char - needs start AND end
+  it.each([
+    ['an empty name', ''],
+    ['a leading dash', '-starts-with-dash'],
+    ['a trailing dash', 'ends-with-dash-'],
+    ['a leading dot', '.starts-with-dot'],
+    ['a trailing dot', 'ends-with-dot.'],
+    ['an empty label between dots', 'a..b'],
+    ['a label starting with a dash', 'a.-b'],
+    ['a space', 'has spaces'],
+    ['a path separator', 'foo/bar'],
+    ['path traversal', '../../admin'],
+    ['one char over the 253 char total', 'a'.repeat(254)],
+    // Under the 253 total, but the first label is over its own 63 char limit
+    ['a label one char over its 63 char limit', `${'a'.repeat(64)}.b`],
+  ])('rejects %s', (_description, name) => {
+    expect(isValidK8sObjectName(name)).toBe(false);
   });
 
-  it('should reject names longer than 253 characters', () => {
-    const longName = 'a'.repeat(254);
-    expect(longName.length > 253).toBe(true);
-    // The regex itself doesn't check length, but the code does
+  // Backstage validates entity names with the Kubernetes *label value* rules,
+  // which are looser than the object name rules the ServiceModel API applies.
+  // These names are legal in Backstage and illegal as object names, which is
+  // the entire reason this check exists.
+  it.each([
+    ['HAS-UPPERCASE', 'uppercase letters'],
+    ['My-Service', 'mixed case'],
+    ['has_underscore', 'an underscore'],
+  ])('rejects %j, which Backstage allows (%s)', name => {
+    expect(isValidK8sObjectName(name)).toBe(false);
+  });
+
+  // Asserted against Backstage's own validator rather than a copy of its regex,
+  // so that if Backstage ever tightens entity names to match Kubernetes object
+  // names, this fails and the check above can be dropped.
+  it('disagrees with Backstage only where Kubernetes is stricter', () => {
+    const { isValidEntityName } = makeValidator();
+
+    for (const name of [
+      'HAS-UPPERCASE',
+      'My-Service',
+      'has_underscore',
+      'a..b',
+    ]) {
+      expect(isValidEntityName(name)).toBe(true);
+      expect(isValidK8sObjectName(name)).toBe(false);
+    }
+
+    // And agrees everywhere else, single characters included
+    for (const name of ['a', '7', 'my-service', 'service.name.with.dots']) {
+      expect(isValidEntityName(name)).toBe(true);
+      expect(isValidK8sObjectName(name)).toBe(true);
+    }
   });
 });
 
@@ -365,6 +410,123 @@ describe('connection backoff', () => {
     expect(logger.info).not.toHaveBeenCalledWith(
       'GrafanaServiceModelProcessor: Connection restored.',
     );
+  });
+
+  it('logs and stays disabled when the startup connection throws', async () => {
+    // A constructor cannot await, so an uncaught rejection here would surface as
+    // an unhandled rejection and take the backend down.
+    connect.mockRejectedValue(new Error('TLS handshake failed'));
+
+    const processor = await newProcessor();
+
+    expect(processor.grafanaAvailable).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('TLS handshake failed'),
+    );
+    // and it still counts as a failure, so the backoff starts where it should
+    expect(lastRetrySeconds()).toBe(60);
+  });
+
+  it('keeps processing entities after the startup connection throws', async () => {
+    connect.mockRejectedValue(new Error('TLS handshake failed'));
+    const processor = await newProcessor();
+
+    await expect(process(processor)).resolves.toBe(entity);
+  });
+});
+
+describe('entities with unusable names', () => {
+  const CONFIG = {
+    grafanaCloudCatalogInfo: {
+      enable: true,
+      stack_slug: 'dev',
+      grafana_endpoint: 'https://grafana-dev.com',
+      token: 'token',
+      allow: ['kind=Component,spec.type=service'],
+    },
+  };
+
+  let logger: jest.Mocked<LoggerService>;
+  let processor: GrafanaServiceModelProcessor;
+
+  beforeEach(() => {
+    logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn(),
+    } as unknown as jest.Mocked<LoggerService>;
+
+    jest
+      .spyOn(
+        GrafanaServiceModelProcessor.prototype,
+        'createAndTestGrafanaConnection',
+      )
+      .mockResolvedValue(true);
+
+    processor = GrafanaServiceModelProcessor.fromConfig({
+      logger,
+      config: new ConfigReader(CONFIG) as Config,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function componentNamed(name: string): Entity {
+    return {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name },
+      spec: { type: 'service' },
+    };
+  }
+
+  it('skips the entity without calling the API', async () => {
+    const getModel = jest.spyOn(processor, 'getModel');
+
+    await expect(
+      processor.createOrUpdateModel(componentNamed('Has-Uppercase')),
+    ).resolves.toBe(false);
+
+    expect(getModel).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Has-Uppercase'),
+    );
+  });
+
+  it('warns once per name, not once per catalog cycle', async () => {
+    jest.spyOn(processor, 'getModel');
+
+    for (let cycle = 0; cycle < 20; cycle++) {
+      await processor.createOrUpdateModel(componentNamed('Has-Uppercase'));
+    }
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns separately for each distinct unusable name', async () => {
+    await processor.createOrUpdateModel(componentNamed('Has-Uppercase'));
+    await processor.createOrUpdateModel(componentNamed('has_underscore'));
+
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('still uploads entities whose names are fine', async () => {
+    const getModel = jest
+      .spyOn(processor, 'getModel')
+      .mockImplementation(async (entity: Entity) =>
+        entityToServiceModel(entity, '', ''),
+      );
+
+    await expect(
+      processor.createOrUpdateModel(componentNamed('a')),
+    ).resolves.toBe(true);
+
+    expect(getModel).toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });
 

--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -1,6 +1,11 @@
 import { Entity } from '@backstage/catalog-model';
-import { Config } from '@backstage/config';
+import { Config, ConfigReader } from '@backstage/config';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
+import {
+  CatalogProcessorCache,
+  CatalogProcessorEmit,
+} from '@backstage/plugin-catalog-node';
 import {
   GrafanaServiceModelProcessor,
   entityToServiceModel,
@@ -216,5 +221,149 @@ describe('entity name validation', () => {
     const longName = 'a'.repeat(254);
     expect(longName.length > 253).toBe(true);
     // The regex itself doesn't check length, but the code does
+  });
+});
+
+describe('connection backoff', () => {
+  const CONFIG = {
+    grafanaCloudCatalogInfo: {
+      enable: true,
+      stack_slug: 'dev',
+      grafana_endpoint: 'https://grafana-dev.com',
+      token: 'token',
+      allow: ['kind=Component,spec.type=service'],
+    },
+  };
+
+  const entity: Entity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'test-entity' },
+    spec: { type: 'service' },
+  };
+
+  let logger: jest.Mocked<LoggerService>;
+  let connect: jest.SpyInstance<Promise<boolean>, []>;
+
+  beforeEach(() => {
+    logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn(),
+    } as unknown as jest.Mocked<LoggerService>;
+
+    connect = jest
+      .spyOn(
+        GrafanaServiceModelProcessor.prototype,
+        'createAndTestGrafanaConnection',
+      )
+      .mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // The constructor kicks off a connection attempt we cannot await, so drain the
+  // microtask queue to let it settle before asserting.
+  async function newProcessor() {
+    const processor = GrafanaServiceModelProcessor.fromConfig({
+      logger,
+      config: new ConfigReader(CONFIG) as Config,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    return processor;
+  }
+
+  function process(processor: GrafanaServiceModelProcessor) {
+    return processor.postProcessEntity!(
+      entity,
+      {} as LocationSpec,
+      jest.fn() as CatalogProcessorEmit,
+      {
+        get: jest.fn().mockResolvedValue(undefined),
+        set: jest.fn().mockResolvedValue(undefined),
+      } as unknown as CatalogProcessorCache,
+    );
+  }
+
+  // Pretend the last attempt happened long enough ago to leave any backoff window
+  function expireBackoff(processor: GrafanaServiceModelProcessor) {
+    processor.lastConnectionAttempt = new Date(Date.now() - 3_600_001);
+  }
+
+  // The "Next retry in Ns." value from the most recent failure warning
+  function lastRetrySeconds(): number {
+    const calls = logger.warn.mock.calls;
+    const message = String(calls[calls.length - 1][0]);
+    return Number(/Next retry in (\d+)s\./.exec(message)![1]);
+  }
+
+  it('attempts the connection once at startup and reports the first backoff', async () => {
+    await newProcessor();
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(lastRetrySeconds()).toBe(60);
+  });
+
+  it('does not retry while inside the backoff window', async () => {
+    const processor = await newProcessor();
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    // Every entity in the cycle passes through, but none of them reconnect
+    for (let i = 0; i < 100; i++) {
+      await expect(process(processor)).resolves.toBe(entity);
+    }
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('doubles the backoff on each consecutive failure, capped at one hour', async () => {
+    const processor = await newProcessor();
+    const observed = [lastRetrySeconds()];
+
+    for (let i = 0; i < 8; i++) {
+      expireBackoff(processor);
+      await process(processor);
+      observed.push(lastRetrySeconds());
+    }
+
+    expect(observed).toEqual([60, 120, 240, 480, 960, 1920, 3600, 3600, 3600]);
+    expect(connect).toHaveBeenCalledTimes(9);
+  });
+
+  it('resets the backoff and logs recovery once the connection comes back', async () => {
+    const processor = await newProcessor();
+
+    connect.mockResolvedValue(true);
+    expireBackoff(processor);
+    await process(processor);
+
+    expect(processor.grafanaAvailable).toBe(true);
+    expect(logger.info).toHaveBeenCalledWith(
+      'GrafanaServiceModelProcessor: Connection restored.',
+    );
+
+    // A later outage starts counting from one again
+    connect.mockResolvedValue(false);
+    processor.grafanaAvailable = false;
+    expireBackoff(processor);
+    await process(processor);
+
+    expect(lastRetrySeconds()).toBe(60);
+  });
+
+  it('stays quiet when the very first connection succeeds', async () => {
+    connect.mockResolvedValue(true);
+    await newProcessor();
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalledWith(
+      'GrafanaServiceModelProcessor: Connection restored.',
+    );
   });
 });

--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -530,6 +530,186 @@ describe('entities with unusable names', () => {
   });
 });
 
+describe('caching uploads', () => {
+  const CONFIG = {
+    grafanaCloudCatalogInfo: {
+      enable: true,
+      stack_slug: 'dev',
+      grafana_endpoint: 'https://grafana-dev.com',
+      token: 'token',
+      allow: ['kind=Component,spec.type=service'],
+    },
+  };
+
+  const entity: Entity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'my-service' },
+    spec: { type: 'service' },
+  };
+
+  let logger: jest.Mocked<LoggerService>;
+  let processor: GrafanaServiceModelProcessor;
+  let upload: jest.SpyInstance<Promise<boolean>, [Entity]>;
+
+  // Stands in for the catalog's per-entity processing cache. The catalog only
+  // persists a new state when it differs from the one it passed in, so "never
+  // written" and "written with the same value" both keep the stored copy.
+  let stored: Entity | undefined;
+  let cache: CatalogProcessorCache;
+  let writes: number;
+
+  beforeEach(() => {
+    logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn(),
+    } as unknown as jest.Mocked<LoggerService>;
+
+    stored = undefined;
+    writes = 0;
+    cache = {
+      get: jest.fn(async () => stored),
+      set: jest.fn(async (_key: string, value: any) => {
+        stored = value;
+        writes++;
+      }),
+    } as unknown as CatalogProcessorCache;
+
+    jest
+      .spyOn(
+        GrafanaServiceModelProcessor.prototype,
+        'createAndTestGrafanaConnection',
+      )
+      .mockResolvedValue(true);
+
+    processor = GrafanaServiceModelProcessor.fromConfig({
+      logger,
+      config: new ConfigReader(CONFIG) as Config,
+    });
+    processor.grafanaAvailable = true;
+
+    upload = jest.spyOn(processor, 'createOrUpdateModel');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const process = () =>
+    processor.postProcessEntity!(
+      entity,
+      {} as LocationSpec,
+      jest.fn() as CatalogProcessorEmit,
+      cache,
+    );
+
+  it('caches the entity once the upload succeeds', async () => {
+    upload.mockResolvedValue(true);
+
+    await expect(process()).resolves.toBe(entity);
+
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(stored).toEqual(entity);
+  });
+
+  it('does not cache the entity when the upload reports failure', async () => {
+    upload.mockResolvedValue(false);
+
+    await expect(process()).resolves.toBe(entity);
+
+    expect(stored).toBeUndefined();
+    expect(writes).toBe(0);
+  });
+
+  it('does not cache the entity when the upload throws', async () => {
+    upload.mockRejectedValue(new Error('429 Too Many Requests'));
+
+    await expect(process()).resolves.toBe(entity);
+
+    expect(stored).toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('429 Too Many Requests'),
+      expect.anything(),
+    );
+  });
+
+  it('retries on the next cycle after a failure, then caches on success', async () => {
+    upload.mockResolvedValue(false);
+    await process();
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    // Nothing was cached, so the next cycle tries again rather than skipping
+    await process();
+    expect(upload).toHaveBeenCalledTimes(2);
+
+    upload.mockResolvedValue(true);
+    await process();
+    expect(upload).toHaveBeenCalledTimes(3);
+    expect(stored).toEqual(entity);
+
+    // And now it stops re-uploading
+    await process();
+    expect(upload).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not touch the cache when the entity is unchanged', async () => {
+    upload.mockResolvedValue(true);
+    await process();
+    expect(writes).toBe(1);
+
+    await process();
+    await process();
+
+    // No further uploads, and no rewrites: leaving the key alone is what keeps
+    // the stored copy, so there is nothing to re-set.
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(writes).toBe(1);
+  });
+
+  it('re-uploads when the entity has changed since it was cached', async () => {
+    upload.mockResolvedValue(true);
+    await process();
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    stored = { ...entity, spec: { type: 'service', owner: 'someone-else' } };
+    await process();
+
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(stored).toEqual(entity);
+  });
+
+  it('waits for the upload before resolving', async () => {
+    let finishUpload!: (value: boolean) => void;
+    upload.mockImplementation(
+      () =>
+        new Promise<boolean>(resolve => {
+          finishUpload = resolve;
+        }),
+    );
+
+    let settled = false;
+    const processing = process().then(result => {
+      settled = true;
+      return result;
+    });
+
+    await new Promise(resolve => setImmediate(resolve));
+    // The catalog snapshots the cache as soon as this resolves, so resolving
+    // early would make the cache write below unpersistable.
+    expect(settled).toBe(false);
+    expect(stored).toBeUndefined();
+
+    finishUpload(true);
+    await processing;
+
+    expect(settled).toBe(true);
+    expect(stored).toEqual(entity);
+  });
+});
+
 describe('upload concurrency', () => {
   const CONFIG = {
     grafanaCloudCatalogInfo: {

--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -132,9 +132,15 @@ describe('config absent', () => {
   it('should not throw when grafanaCloudCatalogInfo config is missing', () => {
     const mockConfig = {
       has: (_key: string) => false,
-      getString: () => { throw new Error('not found'); },
-      getStringArray: () => { throw new Error('not found'); },
-      getBoolean: () => { throw new Error('not found'); },
+      getString: () => {
+        throw new Error('not found');
+      },
+      getStringArray: () => {
+        throw new Error('not found');
+      },
+      getBoolean: () => {
+        throw new Error('not found');
+      },
     } as unknown as Config;
 
     const mockLogger = {
@@ -145,16 +151,25 @@ describe('config absent', () => {
     } as unknown as LoggerService;
 
     expect(() => {
-      GrafanaServiceModelProcessor.fromConfig({ config: mockConfig, logger: mockLogger });
+      GrafanaServiceModelProcessor.fromConfig({
+        config: mockConfig,
+        logger: mockLogger,
+      });
     }).not.toThrow();
   });
 
   it('should log that it is disabled when config is absent', () => {
     const mockConfig = {
       has: (_key: string) => false,
-      getString: () => { throw new Error('not found'); },
-      getStringArray: () => { throw new Error('not found'); },
-      getBoolean: () => { throw new Error('not found'); },
+      getString: () => {
+        throw new Error('not found');
+      },
+      getStringArray: () => {
+        throw new Error('not found');
+      },
+      getBoolean: () => {
+        throw new Error('not found');
+      },
     } as unknown as Config;
 
     const mockLogger = {
@@ -164,7 +179,10 @@ describe('config absent', () => {
       error: jest.fn(),
     } as unknown as LoggerService;
 
-    GrafanaServiceModelProcessor.fromConfig({ config: mockConfig, logger: mockLogger });
+    GrafanaServiceModelProcessor.fromConfig({
+      config: mockConfig,
+      logger: mockLogger,
+    });
     expect(mockLogger.info).toHaveBeenCalledWith(
       expect.stringContaining('No grafanaCloudCatalogInfo config found'),
     );

--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -367,3 +367,112 @@ describe('connection backoff', () => {
     );
   });
 });
+
+describe('upload concurrency', () => {
+  const CONFIG = {
+    grafanaCloudCatalogInfo: {
+      enable: true,
+      stack_slug: 'dev',
+      grafana_endpoint: 'https://grafana-dev.com',
+      token: 'token',
+      allow: ['kind=Component,spec.type=service'],
+    },
+  };
+
+  let logger: LoggerService;
+
+  beforeEach(() => {
+    logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn(),
+    } as unknown as LoggerService;
+
+    jest
+      .spyOn(
+        GrafanaServiceModelProcessor.prototype,
+        'createAndTestGrafanaConnection',
+      )
+      .mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function componentNamed(name: string): Entity {
+    return {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name },
+      spec: { type: 'service' },
+    };
+  }
+
+  it('never has more than 10 uploads in flight at once', async () => {
+    const processor = GrafanaServiceModelProcessor.fromConfig({
+      logger,
+      config: new ConfigReader(CONFIG) as Config,
+    });
+
+    let active = 0;
+    let peak = 0;
+
+    // Resolve with a model identical to the one the processor would build, so
+    // createOrUpdateModel decides nothing has changed and makes no further calls.
+    jest
+      .spyOn(processor, 'getModel')
+      .mockImplementation(async (entity: Entity) => {
+        active++;
+        peak = Math.max(peak, active);
+        await new Promise(resolve => setImmediate(resolve));
+        active--;
+        return entityToServiceModel(entity, '', '');
+      });
+
+    const entities = Array.from({ length: 50 }, (_, i) =>
+      componentNamed(`entity-${i}`),
+    );
+    const results = await Promise.all(
+      entities.map(entity => processor.createOrUpdateModel(entity)),
+    );
+
+    expect(results.every(result => result === true)).toBe(true);
+    expect(peak).toBe(10);
+    expect(active).toBe(0);
+  });
+
+  it('releases the slot when an upload fails', async () => {
+    const processor = GrafanaServiceModelProcessor.fromConfig({
+      logger,
+      config: new ConfigReader(CONFIG) as Config,
+    });
+
+    // 404 means "not there yet", which createOrUpdateModel turns into a create
+    const notFound = Object.assign(new Error('nope'), { code: 500 });
+    jest.spyOn(processor, 'getModel').mockRejectedValue(notFound);
+
+    // Twelve failures against a limit of ten: if a failing upload leaked its
+    // slot, the last two would never run.
+    const attempts = Array.from({ length: 12 }, (_, i) =>
+      processor.createOrUpdateModel(componentNamed(`entity-${i}`)),
+    );
+
+    await expect(Promise.allSettled(attempts)).resolves.toHaveLength(12);
+    for (const attempt of attempts) {
+      await expect(attempt).rejects.toThrow('nope');
+    }
+
+    // The semaphore is not wedged
+    jest
+      .spyOn(processor, 'getModel')
+      .mockImplementation(async (entity: Entity) =>
+        entityToServiceModel(entity, '', ''),
+      );
+    await expect(
+      processor.createOrUpdateModel(componentNamed('after-failures')),
+    ).resolves.toBe(true);
+  });
+});

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -285,15 +285,19 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
           resolve(true);
           return;
         } catch (error: any) {
+          // Deliberately no error.body: k8s API error bodies can carry request
+          // detail we do not want in the logs.
           this.logger.error(
             `GrafanaServiceModelProcessor: k8s not available. Error: ${
-              error?.message || error?.toString() || 'Unknown error'
-            }. Details: ${JSON.stringify({
-              name: error?.name,
-              code: error?.code,
-              status: error?.status,
-              body: error?.body,
-            })}`,
+              error?.message || String(error) || 'Unknown error'
+            }`,
+            {
+              error: {
+                name: error?.name,
+                code: error?.code,
+                status: error?.status,
+              },
+            },
           );
           resolve(false);
           return;
@@ -588,10 +592,15 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         );
       })
       .catch((err: any) => {
+        // JSON.stringify on an Error yields '{}' because message and stack are
+        // non-enumerable, so this used to log nothing useful at all.
         this.logger.error(
-          `GrafanaServiceModelProcessor.updateModel error: ${JSON.stringify(
-            err,
-          )}`,
+          `GrafanaServiceModelProcessor.updateModel error: ${
+            err?.message || String(err) || 'Unknown error'
+          }`,
+          {
+            error: { name: err?.name, code: err?.code, status: err?.status },
+          },
         );
         throw err;
       });
@@ -653,9 +662,12 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
             })
             .catch((e: any) => {
               this.logger.error(
-                `GrafanaServiceModelProcessor.createModel error: ${JSON.stringify(
-                  e,
-                )} ${JSON.stringify(e)}`,
+                `GrafanaServiceModelProcessor.createModel error: ${
+                  e?.message || String(e) || 'Unknown error'
+                }`,
+                {
+                  error: { name: e?.name, code: e?.code, status: e?.status },
+                },
               );
             });
         })

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -405,7 +405,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         // firing or incidents in progress.
         _.unset(storedModel, 'spec.metadata.uid');
 
-        // We need to check if the entity has changed, so we need to convert the entity 
+        // We need to check if the entity has changed, so we need to convert the entity
         // to the same format as the model.
         const entityModel = entityToServiceModel(
           entity,

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -28,6 +28,7 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import { getGrafanaCloudK8sConfig } from './kube_config';
 
 import { anyOfMultipleFilters, entityMatch } from './entityFilter';
+import { Semaphore } from './semaphore';
 
 const API_GROUP = 'servicemodel.ext.grafana.com';
 
@@ -36,6 +37,11 @@ const API_GROUP = 'servicemodel.ext.grafana.com';
 // entity per catalog cycle, which in a large catalog is millions of errors.
 const BACKOFF_BASE_MS = 60_000;
 const BACKOFF_MAX_MS = 3_600_000;
+
+// The catalog hands us one entity at a time but does not wait for us, so in a
+// large catalog every entity's upload starts at once. Cap the in-flight requests
+// so we do not get rate limited by the ServiceModel API.
+const MAX_CONCURRENT_K8S_REQUESTS = 10;
 
 const LABELS = {
   OWNER: `${API_GROUP}/owner`,
@@ -85,6 +91,8 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
   k8sNamespace: string = '';
   // The filter for entities that are allowed to be uploaded
   filter: EntityFilter;
+  // Caps how many ServiceModel API requests are in flight at once
+  private readonly semaphore = new Semaphore(MAX_CONCURRENT_K8S_REQUESTS);
 
   /**
    * fromComfig creates a new GrafanaServiceModelProcessor from the config
@@ -429,11 +437,25 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
   }
 
   /**
-   * createOrUpdateModel creates or updates the entity in the GrafanaServiceModel
+   * createOrUpdateModel creates or updates the entity in the GrafanaServiceModel,
+   * waiting for a free request slot first.
    * @param entity - The entity to create or update in the GrafanaServiceModel
    * @returns - A promise that resolves to true if the entity was created or updated, false otherwise
    */
   async createOrUpdateModel(entity: Entity): Promise<boolean> {
+    // The slot is held until the whole upload settles, so no more than
+    // MAX_CONCURRENT_K8S_REQUESTS uploads are ever in flight.
+    return this.semaphore.run(() => this.uploadModel(entity));
+  }
+
+  /**
+   * uploadModel gets, then creates or replaces, the entity's model in the
+   * GrafanaServiceModel. Callers should go through createOrUpdateModel so that
+   * the concurrency limit is applied.
+   * @param entity - The entity to upload
+   * @returns - A promise that resolves to true if the entity was created or updated, false otherwise
+   */
+  private async uploadModel(entity: Entity): Promise<boolean> {
     // This is where we convert the Backstage entity to the GrafanaServiceModel makeing any
     // shape changes needed to conform to the GrafanaServiceModel API
     const model: KubernetesObjectWithSpec = entityToServiceModel(

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -412,58 +412,60 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         );
 
         const CACHE_KEY = stringifyEntityRef(entity);
-        cache.get(CACHE_KEY).then(cachedEntity => {
-          if (!cachedEntity) {
-            this.logger.debug(
-              `GrafanaServiceModelProcessor.postProcessEntity entity '${entity.kind}' with name '${entity.metadata.name}' not found in cache`,
-            );
-          } else if (!_.isEqual(entity, cachedEntity)) {
-            this.logger.debug(
-              `GrafanaServiceModelProcessor.postProcessEntity entity '${entity.kind}' with name '${entity.metadata.name}' differs from cached version`,
-            );
-          }
+        const cachedEntity = await cache.get(CACHE_KEY);
 
-          if (!cachedEntity || !_.isEqual(entity, cachedEntity)) {
-            this.createOrUpdateModel(entity)
-              .then(async result => {
-                if (result) {
-                  // Update the cache if we were successful in storing the model
-                  cache.set(CACHE_KEY, entity);
-                  // resolve(entity);
-                  // return;
-                }
-              })
-              .catch((err: any) => {
-                this.logger.error(
-                  `GrafanaServiceModelProcessor.postProcessEntity error: ${
-                    err.message || 'Unknown error'
-                  }`,
-                  {
-                    error: {
-                      name: err.name,
-                      message: err.message,
-                      stack: err.stack,
-                      ...(err instanceof Error ? {} : { details: err }),
-                    },
-                    entity: {
-                      kind: entity.kind,
-                      metadata: {
-                        name: entity.metadata.name,
-                        namespace: entity.metadata.namespace,
-                      },
-                    },
-                  },
-                );
-                // Eat the error, we don't want to stop the catalog from processing
-                // don't cache the entity, we will want to procees it again.
-              });
-          }
-          // The cache is ephemeral between invocations, so we need to add the entity to the cache
-          // on every invocation.
-          cache.set(CACHE_KEY, entity);
+        if (cachedEntity && _.isEqual(entity, cachedEntity)) {
+          // Already uploaded and unchanged. Writing nothing to the cache leaves
+          // the stored copy in place: the catalog only persists a new cache
+          // state when it differs from the one it handed us.
           resolve(entity);
           return;
-        });
+        }
+
+        this.logger.debug(
+          cachedEntity
+            ? `GrafanaServiceModelProcessor.postProcessEntity entity '${entity.kind}' with name '${entity.metadata.name}' differs from cached version`
+            : `GrafanaServiceModelProcessor.postProcessEntity entity '${entity.kind}' with name '${entity.metadata.name}' not found in cache`,
+        );
+
+        // Awaited deliberately. The catalog snapshots the cache as soon as this
+        // promise resolves, so a cache write from a still-running upload would
+        // arrive too late to be persisted.
+        let uploaded = false;
+        try {
+          uploaded = await this.createOrUpdateModel(entity);
+        } catch (err: any) {
+          this.logger.error(
+            `GrafanaServiceModelProcessor.postProcessEntity error: ${
+              err.message || 'Unknown error'
+            }`,
+            {
+              error: {
+                name: err.name,
+                message: err.message,
+                stack: err.stack,
+                ...(err instanceof Error ? {} : { details: err }),
+              },
+              entity: {
+                kind: entity.kind,
+                metadata: {
+                  name: entity.metadata.name,
+                  namespace: entity.metadata.namespace,
+                },
+              },
+            },
+          );
+          // Eat the error, we don't want to stop the catalog from processing.
+        }
+
+        if (uploaded) {
+          cache.set(CACHE_KEY, entity);
+        }
+        // On failure the cache is deliberately left alone, so this entity is
+        // tried again on the next cycle instead of being treated as uploaded.
+
+        resolve(entity);
+        return;
       }
     });
   }

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -43,6 +43,23 @@ const BACKOFF_MAX_MS = 3_600_000;
 // so we do not get rate limited by the ServiceModel API.
 const MAX_CONCURRENT_K8S_REQUESTS = 10;
 
+// A Kubernetes object name must be an RFC 1123 DNS subdomain: up to 253 chars
+// of dot-separated DNS labels, each at most 63 chars of lowercase alphanumerics
+// and dashes, starting and ending alphanumeric.
+//
+// Backstage's own entity name rule is looser. isValidEntityName in
+// @backstage/catalog-model is isValidObjectName:
+//
+//   value.length >= 1 && value.length <= 63 &&
+//   /^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$/.test(value)
+//
+// which follows the Kubernetes *label value* rules, not the object name rules.
+// So a name Backstage accepts can still be illegal here in three ways:
+// uppercase letters, underscores, and empty dot-separated segments ('a..b').
+const MAX_OBJECT_NAME_LENGTH = 253;
+const MAX_DNS_LABEL_LENGTH = 63;
+const DNS_LABEL = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
 const LABELS = {
   OWNER: `${API_GROUP}/owner`,
   SYSTEM: `${API_GROUP}/system`,
@@ -93,6 +110,8 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
   filter: EntityFilter;
   // Caps how many ServiceModel API requests are in flight at once
   private readonly semaphore = new Semaphore(MAX_CONCURRENT_K8S_REQUESTS);
+  // Entity names already reported as unusable, so each is only logged once
+  private readonly warnedAboutNames = new Set<string>();
 
   /**
    * fromComfig creates a new GrafanaServiceModelProcessor from the config
@@ -158,10 +177,23 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
     }
 
     this.lastConnectionAttempt = new Date();
-    this.createAndTestGrafanaConnection().then(result => {
-      this.grafanaAvailable = result;
-      this.recordConnectionResult(result);
-    });
+    this.createAndTestGrafanaConnection()
+      .then(result => {
+        this.grafanaAvailable = result;
+        this.recordConnectionResult(result);
+      })
+      .catch(error => {
+        // A constructor cannot await, so without this catch a rejection here is
+        // an unhandled rejection, which terminates the backend by default in
+        // Node 16 and later.
+        this.logger.error(
+          `GrafanaServiceModelProcessor: Initial connection attempt threw: ${
+            error?.message || String(error)
+          }`,
+        );
+        this.grafanaAvailable = false;
+        this.recordConnectionResult(false);
+      });
   }
 
   /**
@@ -443,9 +475,34 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
    * @returns - A promise that resolves to true if the entity was created or updated, false otherwise
    */
   async createOrUpdateModel(entity: Entity): Promise<boolean> {
+    // Checked before taking a slot, since a name we will not send is not worth
+    // queueing behind the entities we will.
+    if (!isValidK8sObjectName(entity.metadata.name)) {
+      this.warnOnceAboutName(entity);
+      return false;
+    }
+
     // The slot is held until the whole upload settles, so no more than
     // MAX_CONCURRENT_K8S_REQUESTS uploads are ever in flight.
     return this.semaphore.run(() => this.uploadModel(entity));
+  }
+
+  /**
+   * warnOnceAboutName reports an entity whose name cannot be used as a
+   * Kubernetes object name. Only the first sighting of each name is logged:
+   * every catalog cycle revisits the same entities, so warning each time would
+   * be the same log flood the reconnect backoff exists to avoid.
+   * @param entity - The entity being skipped
+   */
+  private warnOnceAboutName(entity: Entity): void {
+    if (this.warnedAboutNames.has(entity.metadata.name)) {
+      return;
+    }
+    this.warnedAboutNames.add(entity.metadata.name);
+
+    this.logger.warn(
+      `GrafanaServiceModelProcessor: Skipping ${entity.kind} '${entity.metadata.name}': the name is not a valid Kubernetes object name, so the ServiceModel API would reject it. Names may only contain lowercase letters, digits, '-' and '.', and must start and end with a letter or digit. Backstage permits uppercase letters and underscores in entity names, Kubernetes does not.`,
+    );
   }
 
   /**
@@ -699,6 +756,25 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
 
 function pluralize(s: string): string {
   return `${s.toLowerCase()}s`;
+}
+
+/**
+ * isValidK8sObjectName reports whether a name can be used as a Kubernetes
+ * object name, and so whether it is safe to put in a ServiceModel API path.
+ * Note that a single character is a valid name.
+ * @param name - The name to check, normally entity.metadata.name
+ * @returns - True if the name is a valid RFC 1123 DNS subdomain
+ */
+export function isValidK8sObjectName(name: string): boolean {
+  if (name.length === 0 || name.length > MAX_OBJECT_NAME_LENGTH) {
+    return false;
+  }
+
+  return name
+    .split('.')
+    .every(
+      label => label.length <= MAX_DNS_LABEL_LENGTH && DNS_LABEL.test(label),
+    );
 }
 
 // According to the k8s spec for labels:

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -30,6 +30,13 @@ import { getGrafanaCloudK8sConfig } from './kube_config';
 import { anyOfMultipleFilters, entityMatch } from './entityFilter';
 
 const API_GROUP = 'servicemodel.ext.grafana.com';
+
+// Reconnect backoff schedule: 1min, 2min, 4min, 8min, ... capped at 1hr.
+// Without this, a persistent connection failure produces one error log per
+// entity per catalog cycle, which in a large catalog is millions of errors.
+const BACKOFF_BASE_MS = 60_000;
+const BACKOFF_MAX_MS = 3_600_000;
+
 const LABELS = {
   OWNER: `${API_GROUP}/owner`,
   SYSTEM: `${API_GROUP}/system`,
@@ -67,6 +74,8 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
   lastConnectionAttempt: Date | undefined = undefined;
   // Lock to prevent multiple simultaneous connection attempts
   private isConnecting: boolean = false;
+  // Number of consecutive connection failures, which drives the retry backoff
+  private consecutiveFailures: number = 0;
 
   // The version of the ServiceModel API we are using
   serviceModelVersion: string = '';
@@ -140,10 +149,44 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
       return;
     }
 
+    this.lastConnectionAttempt = new Date();
     this.createAndTestGrafanaConnection().then(result => {
       this.grafanaAvailable = result;
-      this.lastConnectionAttempt = new Date();
+      this.recordConnectionResult(result);
     });
+  }
+
+  /**
+   * connectionBackoffMs is how long to wait before the next connection attempt,
+   * based on how many consecutive failures we have seen.
+   * @returns - The backoff window in milliseconds
+   */
+  private connectionBackoffMs(): number {
+    const doublings = Math.max(0, this.consecutiveFailures - 1);
+    return Math.min(BACKOFF_BASE_MS * 2 ** doublings, BACKOFF_MAX_MS);
+  }
+
+  /**
+   * recordConnectionResult updates the failure count that drives the backoff and
+   * logs the transition. Only logs on failure or on recovery, so a healthy
+   * connection stays quiet.
+   * @param connected - Whether the connection attempt succeeded
+   */
+  private recordConnectionResult(connected: boolean): void {
+    if (connected) {
+      if (this.consecutiveFailures > 0) {
+        this.logger.info('GrafanaServiceModelProcessor: Connection restored.');
+      }
+      this.consecutiveFailures = 0;
+      return;
+    }
+
+    this.consecutiveFailures++;
+    this.logger.warn(
+      `GrafanaServiceModelProcessor: Connection failed (attempt ${
+        this.consecutiveFailures
+      }). Next retry in ${Math.round(this.connectionBackoffMs() / 1000)}s.`,
+    );
   }
 
   /**
@@ -169,19 +212,6 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
           this.logger.debug(
             'GrafanaServiceModelProcessor: Trying to get connection to Grafana Cloud.',
           );
-
-          const now = new Date();
-          if (
-            this.lastConnectionAttempt !== undefined &&
-            now.getTime() - this.lastConnectionAttempt.getTime() < 1000
-          ) {
-            this.logger.debug(
-              'GrafanaServiceModelProcessor: Trying to get connection to Grafana Cloud too soon after last attempt.',
-            );
-            resolve(false);
-            return;
-          }
-          this.lastConnectionAttempt = now;
 
           try {
             // Get the Grafana Cloud K8s Config using configured Cloud Access Policies
@@ -298,8 +328,24 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         resolve(entity);
         return;
       } else if (!this.grafanaAvailable) {
+        // Still inside the backoff window from the last failure. Stay quiet and
+        // let a later entity trigger the retry.
+        const now = new Date();
+        if (
+          this.lastConnectionAttempt !== undefined &&
+          now.getTime() - this.lastConnectionAttempt.getTime() <
+            this.connectionBackoffMs()
+        ) {
+          resolve(entity);
+          return;
+        }
+
+        // Claimed synchronously so the other entities in this cycle see the new
+        // window and only one of them actually attempts the reconnect.
+        this.lastConnectionAttempt = now;
         await this.createAndTestGrafanaConnection().then(result => {
           this.grafanaAvailable = result;
+          this.recordConnectionResult(result);
           // Catch you next time
           resolve(entity);
           return;

--- a/src/semaphore.test.ts
+++ b/src/semaphore.test.ts
@@ -1,0 +1,141 @@
+import { Semaphore } from './semaphore';
+
+// A promise with an externally controlled settle time, so tests can hold tasks
+// open and decide exactly when they finish.
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const tick = () => new Promise(resolve => setImmediate(resolve));
+
+describe('Semaphore', () => {
+  it('rejects a nonsensical limit', () => {
+    expect(() => new Semaphore(0)).toThrow(/positive integer/);
+    expect(() => new Semaphore(-1)).toThrow(/positive integer/);
+    expect(() => new Semaphore(1.5)).toThrow(/positive integer/);
+  });
+
+  it('holds the slot until the task settles, not until it starts', async () => {
+    const sem = new Semaphore(1);
+    const first = deferred();
+    let secondStarted = false;
+
+    const firstRun = sem.run(() => first.promise);
+    const secondRun = sem.run(async () => {
+      secondStarted = true;
+    });
+
+    // The first task is still pending, so the second must not have begun. This
+    // is the case that breaks if the slot is freed when the task's promise is
+    // created rather than when it settles.
+    await tick();
+    expect(secondStarted).toBe(false);
+
+    first.resolve();
+    await Promise.all([firstRun, secondRun]);
+    expect(secondStarted).toBe(true);
+  });
+
+  it('never runs more than maxConcurrency tasks at once', async () => {
+    const sem = new Semaphore(3);
+    let active = 0;
+    let peak = 0;
+
+    await Promise.all(
+      Array.from({ length: 30 }, () =>
+        sem.run(async () => {
+          active++;
+          peak = Math.max(peak, active);
+          await tick();
+          active--;
+        }),
+      ),
+    );
+
+    expect(peak).toBe(3);
+    expect(active).toBe(0);
+  });
+
+  it('lets waiting tasks through in the order they arrived', async () => {
+    const sem = new Semaphore(1);
+    const blocker = deferred();
+    const order: number[] = [];
+
+    const runs = [
+      sem.run(() => blocker.promise),
+      ...[1, 2, 3, 4].map(n =>
+        sem.run(async () => {
+          order.push(n);
+        }),
+      ),
+    ];
+
+    blocker.resolve();
+    await Promise.all(runs);
+
+    expect(order).toEqual([1, 2, 3, 4]);
+  });
+
+  it('frees the slot when a task rejects', async () => {
+    const sem = new Semaphore(1);
+
+    await expect(
+      sem.run(() => Promise.reject(new Error('task blew up'))),
+    ).rejects.toThrow('task blew up');
+
+    // A leaked slot would leave the semaphore permanently full
+    await expect(sem.run(async () => 'still works')).resolves.toBe(
+      'still works',
+    );
+  });
+
+  it('frees the slot when a task throws synchronously', async () => {
+    const sem = new Semaphore(1);
+
+    await expect(
+      sem.run(() => {
+        throw new Error('threw before returning');
+      }),
+    ).rejects.toThrow('threw before returning');
+
+    await expect(sem.run(async () => 'still works')).resolves.toBe(
+      'still works',
+    );
+  });
+
+  it('passes the task result through', async () => {
+    const sem = new Semaphore(2);
+
+    await expect(sem.run(async () => 42)).resolves.toBe(42);
+  });
+
+  it('keeps its limit across successive batches', async () => {
+    const sem = new Semaphore(2);
+    let peak = 0;
+    let active = 0;
+
+    const batch = () =>
+      Promise.all(
+        Array.from({ length: 5 }, () =>
+          sem.run(async () => {
+            active++;
+            peak = Math.max(peak, active);
+            await tick();
+            active--;
+          }),
+        ),
+      );
+
+    await batch();
+    await batch();
+
+    expect(peak).toBe(2);
+    expect(active).toBe(0);
+  });
+});

--- a/src/semaphore.ts
+++ b/src/semaphore.ts
@@ -1,0 +1,64 @@
+/**
+ * Semaphore bounds how many tasks may run at the same time. Tasks beyond the
+ * limit wait for a slot, in the order they asked for one.
+ *
+ * run() is the only way in. Acquiring and releasing are private because
+ * pairing them by hand is easy to get wrong: in an async function,
+ *
+ *   try { return somePromise } finally { release() }
+ *
+ * releases the slot as soon as somePromise is *created*, not when it settles,
+ * which silently removes all throttling.
+ */
+export class Semaphore {
+  // Resolvers for callers waiting on a slot, oldest first
+  private readonly waiting: Array<() => void> = [];
+  // Number of slots currently held
+  private inFlight: number = 0;
+
+  constructor(private readonly maxConcurrency: number) {
+    if (!Number.isInteger(maxConcurrency) || maxConcurrency < 1) {
+      throw new Error(
+        `Semaphore: maxConcurrency must be a positive integer, got ${maxConcurrency}`,
+      );
+    }
+  }
+
+  /**
+   * run waits for a free slot, runs the task, and frees the slot once the task
+   * settles, whether it resolves or rejects.
+   * @param task - The work to run while holding a slot
+   * @returns - Whatever the task resolves to
+   */
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      // `return await` is load-bearing. A bare `return` would run the finally
+      // block as soon as the task's promise is created.
+      return await task();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.inFlight < this.maxConcurrency) {
+      this.inFlight++;
+      return Promise.resolve();
+    }
+    return new Promise<void>(resolve => {
+      this.waiting.push(resolve);
+    });
+  }
+
+  private release(): void {
+    // Hand the slot directly to the next waiter instead of decrementing and
+    // letting it re-acquire, so inFlight never dips and no waiter is skipped.
+    const next = this.waiting.shift();
+    if (next) {
+      next();
+      return;
+    }
+    this.inFlight--;
+  }
+}


### PR DESCRIPTION
Integrates #162, #163, #164 and #165, and fixes #176.

Each upstream PR is reviewed and integrated as its own commit, plus one commit for #176 which came out of reviewing #164. `main` is unchanged apart from `src/`; no dependency or lockfile changes.

## Heads-up: the source branches do not match their PR descriptions

All four PRs branch off `396a8f3` and are a partially-rebased stack whose contents got shuffled. The net diff of each branch is not what its body describes:

| PR | Body describes | Branch actually contains |
|----|----------------|--------------------------|
| #162 | backoff | backoff |
| #163 | sanitize logs + HTTP timeout | backoff + constructor catch + name validation |
| #164 | semaphore | sanitize + timeout + constructor catch + validation + semaphore |
| #165 | constructor catch + validation | all four, minus `semaphore.test.ts` |

Cherry-picking by PR number would have produced duplicates and dropped the sanitize/timeout work entirely. So this integrates the four *logical* changes, one per commit, each mapped to the PR whose description claims it. **#162–#165 can all be closed by this PR**, but reviewers comparing against the branches should expect the contents to be shuffled.

## What each commit does

**#162 — reconnect backoff.** Retries back off 1min → 2min → … → 1hr instead of once per entity per cycle. Extracted `connectionBackoffMs()` and `recordConnectionResult()` so the backoff window and the "next retry in Ns" log cannot drift; upstream duplicated the calculation in two places in different units. Fixed the constructor accounting: it recorded a startup attempt without incrementing the failure count, so a failed startup burned a silent 60s window with no "attempt 1" log — the diagnostic the PR exists to add. "Connection restored" no longer logs on first connect.

**#163 — sanitize error logs, add a 30s GCOM timeout.** The stated motivation is `error.body`; the bigger find is that `updateModel` and `createModel` logged `JSON.stringify(err)`, which on an `Error` is `{}` because `message` and `stack` are non-enumerable — those two error logs have been emitting no diagnostic content at all, and `createModel` emitted it twice. Collapsed the two near-identical 40-line `https.get` blocks into one `getJson()` helper so the timeout exists once; that is why this diff is smaller than upstream's, which rewrote 138 lines to add two. Restored a `String(error)` fallback upstream dropped, which would have logged "Unknown error" with everything undefined for any non-`Error` throw.

**#164 — cap concurrent API requests at 10.** As written upstream this had no throttling effect: `await acquire(); try { return getModel().then(...) } finally { release() }` releases the slot when the return expression is *evaluated*, not when the promise settles. Fixed with `return await`; four of the new tests fail if it is reduced to a bare `return`. `acquire`/`release` are now private with `run()` the only entry point, so the pairing is structural rather than a convention. Upstream's `release()` also decremented unconditionally, driving the counter negative and permanently raising the effective limit — its test asserted only that this did not throw.

**#165 — constructor catch and entity name validation.** Upstream's regex `/^[a-z0-9][a-z0-9\-.]*[a-z0-9]$/` rejected every single-character name, because two anchored character classes cannot both match one character. `a` and `7` are valid in both Backstage and Kubernetes, so this silently skipped legitimate entities — and its test asserted the rejection as intended. Replaced with a real RFC 1123 DNS subdomain check (per-label 63, total 253); upstream accepted `a..b` and `a.-b`, which the API rejects, and ignored the per-label limit. The check runs before the concurrency slot is taken, and each unusable name is warned about once rather than once per cycle.

**#176 — only cache after a successful upload.** `postProcessEntity` wrote the cache unconditionally before the upload finished, so a failed upload was recorded as a success and the entity was skipped forever after. This made both surrounding guards dead code: the `if (result) cache.set(...)` never decided anything, and the `.catch` comment "don't cache the entity, we will want to process it again" described the opposite of what happened. Any transient failure dropped that entity permanently. This is plausibly a bigger contributor to the dropped-entity symptom #164 was written to address than rate limiting is.

### Why #176 required awaiting the upload

The catalog snapshots the processing cache the moment `postProcessEntity` resolves, so a cache write from a still-running upload arrives too late to persist. The unconditional write was the only reason caching worked at all.

Verified against the catalog's own `ProcessorCacheManager` that *not* writing a key preserves the stored value — `collect()` returns `newState ?? existingState`, and `DefaultCatalogProcessingEngine` only calls `updateEntityCache` when the collected state differs from what it passed in. So the "cache is ephemeral between invocations" comment this replaces was incorrect. The cache is not permanent either: the engine decrements a ttl (`CACHE_TTL = 5`) on each run where the entity's processing reports errors and wipes the state at zero — but that is driven by the entity failing validation, not by our upload failing.

**This is a behaviour change worth a second opinion:** catalog processing now waits on the ServiceModel API. That is real backpressure rather than fire-and-forget, but the K8s client calls have no timeout, so a hung request now stalls that entity's processing and holds its concurrency slot. Tracked in #179.

## Backstage vs Kubernetes name rules

Since the value of the #165 check depends on it — `makeValidator().isValidEntityName` in `@backstage/catalog-model` is `isValidObjectName`:

```js
value.length >= 1 && value.length <= 63 &&
/^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$/.test(value)
```

That follows the Kubernetes **label value** rules, not the **object name** rules, despite the function name. Three classes of name are legal in Backstage and illegal as an object name: uppercase letters, underscores, and empty dot-segments (`a..b`). Everything else Backstage accepts is a valid object name. There is a test asserting this divergence via Backstage's own validator rather than a copy of its regex, so it fails if Backstage ever tightens the rule and the check can then be deleted.

## Tests

17 → 75. New coverage for the backoff window, doubling and cap; GCOM timeout, abort, network error and parse failure, plus that the bearer token stays out of logs; semaphore peak concurrency, FIFO order and slot release on rejection; name validation as a table including the single-char cases; and the caching behaviour in both directions.

Three notes on the existing suite:
- `kube_config.ts` had no tests. `getIdFromSlug` and `getGrafanaConnectionInfo` are now exported to make them reachable — not re-exported from `index.ts`, so the package's public API is unchanged. `getGrafanaCloudK8sConfig` still cannot be tested at all (#175).
- The `entity name validation` block #160 left in `processor.test.ts` tested a regex literal declared in the test file, not production code, so it passed regardless of behaviour. Replaced with tests against the real function.
- The first commit is pure `prettier` on pre-existing drift from #160, isolated so the review commits stay readable.

## Filed, not fixed

Found during review and left for follow-ups rather than widening this PR: #172 (mid-run outages do not back off — #162 only covers a failed startup), #173, #174, #175, #177, #178, #179, #181 (`createAndTestGrafanaConnection` has the same `try`/`finally` defect as #164, making its `isConnecting` lock a no-op, and its `new Promise(async …)` executor can leave the promise pending forever).

That last one is worth flagging: the same async-`finally` mistake appears twice independently in this file.

## Verification

`yarn tsc`, `yarn lint`, `yarn build` and `yarn test` all pass. Rebased onto `b8efc5f`.

Closes #162
Closes #163
Closes #164
Closes #165
Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)
