### PR TITLE
fix: add exponential backoff on connection failure (#162) [1/6]

### DIFF
--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -1,6 +1,11 @@
 import { Entity } from '@backstage/catalog-model';
-import { Config } from '@backstage/config';
+import { Config, ConfigReader } from '@backstage/config';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
+import {
+  CatalogProcessorCache,
+  CatalogProcessorEmit,
+} from '@backstage/plugin-catalog-node';
 import {
   GrafanaServiceModelProcessor,
   entityToServiceModel,
@@ -216,5 +221,149 @@ describe('entity name validation', () => {
     const longName = 'a'.repeat(254);
     expect(longName.length > 253).toBe(true);
     // The regex itself doesn't check length, but the code does
+  });
+});
+
+describe('connection backoff', () => {
+  const CONFIG = {
+    grafanaCloudCatalogInfo: {
+      enable: true,
+      stack_slug: 'dev',
+      grafana_endpoint: 'https://grafana-dev.com',
+      token: 'token',
+      allow: ['kind=Component,spec.type=service'],
+    },
+  };
+
+  const entity: Entity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'test-entity' },
+    spec: { type: 'service' },
+  };
+
+  let logger: jest.Mocked<LoggerService>;
+  let connect: jest.SpyInstance<Promise<boolean>, []>;
+
+  beforeEach(() => {
+    logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn(),
+    } as unknown as jest.Mocked<LoggerService>;
+
+    connect = jest
+      .spyOn(
+        GrafanaServiceModelProcessor.prototype,
+        'createAndTestGrafanaConnection',
+      )
+      .mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // The constructor kicks off a connection attempt we cannot await, so drain the
+  // microtask queue to let it settle before asserting.
+  async function newProcessor() {
+    const processor = GrafanaServiceModelProcessor.fromConfig({
+      logger,
+      config: new ConfigReader(CONFIG) as Config,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    return processor;
+  }
+
+  function process(processor: GrafanaServiceModelProcessor) {
+    return processor.postProcessEntity!(
+      entity,
+      {} as LocationSpec,
+      jest.fn() as CatalogProcessorEmit,
+      {
+        get: jest.fn().mockResolvedValue(undefined),
+        set: jest.fn().mockResolvedValue(undefined),
+      } as unknown as CatalogProcessorCache,
+    );
+  }
+
+  // Pretend the last attempt happened long enough ago to leave any backoff window
+  function expireBackoff(processor: GrafanaServiceModelProcessor) {
+    processor.lastConnectionAttempt = new Date(Date.now() - 3_600_001);
+  }
+
+  // The "Next retry in Ns." value from the most recent failure warning
+  function lastRetrySeconds(): number {
+    const calls = logger.warn.mock.calls;
+    const message = String(calls[calls.length - 1][0]);
+    return Number(/Next retry in (\d+)s\./.exec(message)![1]);
+  }
+
+  it('attempts the connection once at startup and reports the first backoff', async () => {
+    await newProcessor();
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(lastRetrySeconds()).toBe(60);
+  });
+
+  it('does not retry while inside the backoff window', async () => {
+    const processor = await newProcessor();
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    // Every entity in the cycle passes through, but none of them reconnect
+    for (let i = 0; i < 100; i++) {
+      await expect(process(processor)).resolves.toBe(entity);
+    }
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('doubles the backoff on each consecutive failure, capped at one hour', async () => {
+    const processor = await newProcessor();
+    const observed = [lastRetrySeconds()];
+
+    for (let i = 0; i < 8; i++) {
+      expireBackoff(processor);
+      await process(processor);
+      observed.push(lastRetrySeconds());
+    }
+
+    expect(observed).toEqual([60, 120, 240, 480, 960, 1920, 3600, 3600, 3600]);
+    expect(connect).toHaveBeenCalledTimes(9);
+  });
+
+  it('resets the backoff and logs recovery once the connection comes back', async () => {
+    const processor = await newProcessor();
+
+    connect.mockResolvedValue(true);
+    expireBackoff(processor);
+    await process(processor);
+
+    expect(processor.grafanaAvailable).toBe(true);
+    expect(logger.info).toHaveBeenCalledWith(
+      'GrafanaServiceModelProcessor: Connection restored.',
+    );
+
+    // A later outage starts counting from one again
+    connect.mockResolvedValue(false);
+    processor.grafanaAvailable = false;
+    expireBackoff(processor);
+    await process(processor);
+
+    expect(lastRetrySeconds()).toBe(60);
+  });
+
+  it('stays quiet when the very first connection succeeds', async () => {
+    connect.mockResolvedValue(true);
+    await newProcessor();
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalledWith(
+      'GrafanaServiceModelProcessor: Connection restored.',
+    );
   });
 });

--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -132,9 +132,15 @@ describe('config absent', () => {
   it('should not throw when grafanaCloudCatalogInfo config is missing', () => {
     const mockConfig = {
       has: (_key: string) => false,
-      getString: () => { throw new Error('not found'); },
-      getStringArray: () => { throw new Error('not found'); },
-      getBoolean: () => { throw new Error('not found'); },
+      getString: () => {
+        throw new Error('not found');
+      },
+      getStringArray: () => {
+        throw new Error('not found');
+      },
+      getBoolean: () => {
+        throw new Error('not found');
+      },
     } as unknown as Config;
 
     const mockLogger = {
@@ -145,16 +151,25 @@ describe('config absent', () => {
     } as unknown as LoggerService;
 
     expect(() => {
-      GrafanaServiceModelProcessor.fromConfig({ config: mockConfig, logger: mockLogger });
+      GrafanaServiceModelProcessor.fromConfig({
+        config: mockConfig,
+        logger: mockLogger,
+      });
     }).not.toThrow();
   });
 
   it('should log that it is disabled when config is absent', () => {
     const mockConfig = {
       has: (_key: string) => false,
-      getString: () => { throw new Error('not found'); },
-      getStringArray: () => { throw new Error('not found'); },
-      getBoolean: () => { throw new Error('not found'); },
+      getString: () => {
+        throw new Error('not found');
+      },
+      getStringArray: () => {
+        throw new Error('not found');
+      },
+      getBoolean: () => {
+        throw new Error('not found');
+      },
     } as unknown as Config;
 
     const mockLogger = {
@@ -164,7 +179,10 @@ describe('config absent', () => {
       error: jest.fn(),
     } as unknown as LoggerService;
 
-    GrafanaServiceModelProcessor.fromConfig({ config: mockConfig, logger: mockLogger });
+    GrafanaServiceModelProcessor.fromConfig({
+      config: mockConfig,
+      logger: mockLogger,
+    });
     expect(mockLogger.info).toHaveBeenCalledWith(
       expect.stringContaining('No grafanaCloudCatalogInfo config found'),
     );

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -405,7 +405,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         // firing or incidents in progress.
         _.unset(storedModel, 'spec.metadata.uid');
 
-        // We need to check if the entity has changed, so we need to convert the entity 
+        // We need to check if the entity has changed, so we need to convert the entity
         // to the same format as the model.
         const entityModel = entityToServiceModel(
           entity,

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -30,6 +30,13 @@ import { getGrafanaCloudK8sConfig } from './kube_config';
 import { anyOfMultipleFilters, entityMatch } from './entityFilter';
 
 const API_GROUP = 'servicemodel.ext.grafana.com';
+
+// Reconnect backoff schedule: 1min, 2min, 4min, 8min, ... capped at 1hr.
+// Without this, a persistent connection failure produces one error log per
+// entity per catalog cycle, which in a large catalog is millions of errors.
+const BACKOFF_BASE_MS = 60_000;
+const BACKOFF_MAX_MS = 3_600_000;
+
 const LABELS = {
   OWNER: `${API_GROUP}/owner`,
   SYSTEM: `${API_GROUP}/system`,
@@ -67,6 +74,8 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
   lastConnectionAttempt: Date | undefined = undefined;
   // Lock to prevent multiple simultaneous connection attempts
   private isConnecting: boolean = false;
+  // Number of consecutive connection failures, which drives the retry backoff
+  private consecutiveFailures: number = 0;
 
   // The version of the ServiceModel API we are using
   serviceModelVersion: string = '';
@@ -140,10 +149,44 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
       return;
     }
 
+    this.lastConnectionAttempt = new Date();
     this.createAndTestGrafanaConnection().then(result => {
       this.grafanaAvailable = result;
-      this.lastConnectionAttempt = new Date();
+      this.recordConnectionResult(result);
     });
+  }
+
+  /**
+   * connectionBackoffMs is how long to wait before the next connection attempt,
+   * based on how many consecutive failures we have seen.
+   * @returns - The backoff window in milliseconds
+   */
+  private connectionBackoffMs(): number {
+    const doublings = Math.max(0, this.consecutiveFailures - 1);
+    return Math.min(BACKOFF_BASE_MS * 2 ** doublings, BACKOFF_MAX_MS);
+  }
+
+  /**
+   * recordConnectionResult updates the failure count that drives the backoff and
+   * logs the transition. Only logs on failure or on recovery, so a healthy
+   * connection stays quiet.
+   * @param connected - Whether the connection attempt succeeded
+   */
+  private recordConnectionResult(connected: boolean): void {
+    if (connected) {
+      if (this.consecutiveFailures > 0) {
+        this.logger.info('GrafanaServiceModelProcessor: Connection restored.');
+      }
+      this.consecutiveFailures = 0;
+      return;
+    }
+
+    this.consecutiveFailures++;
+    this.logger.warn(
+      `GrafanaServiceModelProcessor: Connection failed (attempt ${
+        this.consecutiveFailures
+      }). Next retry in ${Math.round(this.connectionBackoffMs() / 1000)}s.`,
+    );
   }
 
   /**
@@ -169,19 +212,6 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
           this.logger.debug(
             'GrafanaServiceModelProcessor: Trying to get connection to Grafana Cloud.',
           );
-
-          const now = new Date();
-          if (
-            this.lastConnectionAttempt !== undefined &&
-            now.getTime() - this.lastConnectionAttempt.getTime() < 1000
-          ) {
-            this.logger.debug(
-              'GrafanaServiceModelProcessor: Trying to get connection to Grafana Cloud too soon after last attempt.',
-            );
-            resolve(false);
-            return;
-          }
-          this.lastConnectionAttempt = now;
 
           try {
             // Get the Grafana Cloud K8s Config using configured Cloud Access Policies
@@ -298,8 +328,24 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         resolve(entity);
         return;
       } else if (!this.grafanaAvailable) {
+        // Still inside the backoff window from the last failure. Stay quiet and
+        // let a later entity trigger the retry.
+        const now = new Date();
+        if (
+          this.lastConnectionAttempt !== undefined &&
+          now.getTime() - this.lastConnectionAttempt.getTime() <
+            this.connectionBackoffMs()
+        ) {
+          resolve(entity);
+          return;
+        }
+
+        // Claimed synchronously so the other entities in this cycle see the new
+        // window and only one of them actually attempts the reconnect.
+        this.lastConnectionAttempt = now;
         await this.createAndTestGrafanaConnection().then(result => {
           this.grafanaAvailable = result;
+          this.recordConnectionResult(result);
           // Catch you next time
           resolve(entity);
           return;


### PR DESCRIPTION
**Stack 1/6.** Base: `main`. Followed by the sanitize/timeout, concurrency, name-validation, caching and request-timeout PRs.

Replaces #184, which carried all of this as one PR.

## Read this first: the source branches do not match their PR descriptions

#162–#165 all branch off `396a8f3` and are a partially-rebased stack whose contents got shuffled. The net diff of each branch is not what its body describes:

| PR | Body describes | Branch actually contains |
|----|----------------|--------------------------|
| #162 | backoff | backoff |
| #163 | sanitize logs + HTTP timeout | backoff + constructor catch + name validation |
| #164 | semaphore | sanitize + timeout + constructor catch + validation + semaphore |
| #165 | constructor catch + validation | all four, minus `semaphore.test.ts` |

Cherry-picking by PR number would have produced duplicates and dropped the sanitize/timeout work entirely. So this stack integrates the four *logical* changes, one per PR, each mapped to the upstream PR whose **description** claims it. Reviewers comparing a PR against its upstream branch should expect the contents to differ.

## This PR: reconnect backoff

Closes #162.

When the connection to Grafana Cloud is down, the processor retried on every entity of every catalog cycle, producing one error log per entity — millions of errors in a large catalog. Retries now back off 1min → 2min → 4min → … capped at 1hr, resetting once the connection is restored.

### Changes from the upstream branch

- Extracted `connectionBackoffMs()` and `recordConnectionResult()`. Upstream duplicated the backoff calculation in two places in different units (ms for the window, seconds for the log message) — two copies that must agree.
- **Fixed the constructor accounting.** Upstream set `lastConnectionAttempt` on a failed startup without incrementing the failure count, so a failed startup burned a silent 60s window with no "attempt 1" log — the exact diagnostic the PR exists to add.
- `"Connection restored"` no longer logs on the first successful connect, where nothing had been lost.
- Added tests: the quiet window (100 entities → 1 attempt), the doubling sequence `[60,120,240,480,960,1920,3600,3600,3600]`, the 1hr cap, and reset-on-recovery.

### Verified, not a problem

The concurrent-entity thundering herd. The window check and `lastConnectionAttempt = now` are synchronous with no `await` between them, so only one entity per window actually reconnects.

### Known gap, filed as #172

`grafanaAvailable` is only ever assigned inside the `!grafanaAvailable` branch, so once the connection is up it never goes down. Per-entity failures are caught and swallowed with it left `true`. This backoff therefore governs the **startup-down** case only; a mid-run outage still logs once per entity per cycle from `createOrUpdateModel`'s catch. That's the bulk of #161 but not all of it.

## Note on the first commit

`chore: run prettier` is pre-existing formatting drift from #160, isolated as its own commit so the review commits stay readable. It sits at the base of the stack.

## Verification

`yarn tsc`, `yarn lint`, `yarn build`, `yarn test` all pass. The equivalent code passed CI in full, including the kind-based Integration job, as #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Stack

| | PR | Base |
|---|---|---|
| 1/6 | #185 — backoff (#162) | `main` |
| 2/6 | #186 — sanitize logs + GCOM timeout (#163) | #185 |
| 3/6 | #187 — concurrency cap (#164) | #186 |
| 4/6 | #188 — constructor catch + name validation (#165) | #187 |
| 5/6 | #189 — cache only on success (#176) | #188 |
| 6/6 | #190 — 30s K8s request timeout | #189 |

Merge in order. Each PR needs its predecessor merged first, or GitHub will show the predecessor's commits in its diff.
