### PR TITLE
fix: cap concurrent ServiceModel API requests (#164) [3/6]

### DIFF
--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -367,3 +367,112 @@ describe('connection backoff', () => {
     );
   });
 });
+
+describe('upload concurrency', () => {
+  const CONFIG = {
+    grafanaCloudCatalogInfo: {
+      enable: true,
+      stack_slug: 'dev',
+      grafana_endpoint: 'https://grafana-dev.com',
+      token: 'token',
+      allow: ['kind=Component,spec.type=service'],
+    },
+  };
+
+  let logger: LoggerService;
+
+  beforeEach(() => {
+    logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn(),
+    } as unknown as LoggerService;
+
+    jest
+      .spyOn(
+        GrafanaServiceModelProcessor.prototype,
+        'createAndTestGrafanaConnection',
+      )
+      .mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function componentNamed(name: string): Entity {
+    return {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name },
+      spec: { type: 'service' },
+    };
+  }
+
+  it('never has more than 10 uploads in flight at once', async () => {
+    const processor = GrafanaServiceModelProcessor.fromConfig({
+      logger,
+      config: new ConfigReader(CONFIG) as Config,
+    });
+
+    let active = 0;
+    let peak = 0;
+
+    // Resolve with a model identical to the one the processor would build, so
+    // createOrUpdateModel decides nothing has changed and makes no further calls.
+    jest
+      .spyOn(processor, 'getModel')
+      .mockImplementation(async (entity: Entity) => {
+        active++;
+        peak = Math.max(peak, active);
+        await new Promise(resolve => setImmediate(resolve));
+        active--;
+        return entityToServiceModel(entity, '', '');
+      });
+
+    const entities = Array.from({ length: 50 }, (_, i) =>
+      componentNamed(`entity-${i}`),
+    );
+    const results = await Promise.all(
+      entities.map(entity => processor.createOrUpdateModel(entity)),
+    );
+
+    expect(results.every(result => result === true)).toBe(true);
+    expect(peak).toBe(10);
+    expect(active).toBe(0);
+  });
+
+  it('releases the slot when an upload fails', async () => {
+    const processor = GrafanaServiceModelProcessor.fromConfig({
+      logger,
+      config: new ConfigReader(CONFIG) as Config,
+    });
+
+    // 404 means "not there yet", which createOrUpdateModel turns into a create
+    const notFound = Object.assign(new Error('nope'), { code: 500 });
+    jest.spyOn(processor, 'getModel').mockRejectedValue(notFound);
+
+    // Twelve failures against a limit of ten: if a failing upload leaked its
+    // slot, the last two would never run.
+    const attempts = Array.from({ length: 12 }, (_, i) =>
+      processor.createOrUpdateModel(componentNamed(`entity-${i}`)),
+    );
+
+    await expect(Promise.allSettled(attempts)).resolves.toHaveLength(12);
+    for (const attempt of attempts) {
+      await expect(attempt).rejects.toThrow('nope');
+    }
+
+    // The semaphore is not wedged
+    jest
+      .spyOn(processor, 'getModel')
+      .mockImplementation(async (entity: Entity) =>
+        entityToServiceModel(entity, '', ''),
+      );
+    await expect(
+      processor.createOrUpdateModel(componentNamed('after-failures')),
+    ).resolves.toBe(true);
+  });
+});

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -28,6 +28,7 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import { getGrafanaCloudK8sConfig } from './kube_config';
 
 import { anyOfMultipleFilters, entityMatch } from './entityFilter';
+import { Semaphore } from './semaphore';
 
 const API_GROUP = 'servicemodel.ext.grafana.com';
 
@@ -36,6 +37,11 @@ const API_GROUP = 'servicemodel.ext.grafana.com';
 // entity per catalog cycle, which in a large catalog is millions of errors.
 const BACKOFF_BASE_MS = 60_000;
 const BACKOFF_MAX_MS = 3_600_000;
+
+// The catalog hands us one entity at a time but does not wait for us, so in a
+// large catalog every entity's upload starts at once. Cap the in-flight requests
+// so we do not get rate limited by the ServiceModel API.
+const MAX_CONCURRENT_K8S_REQUESTS = 10;
 
 const LABELS = {
   OWNER: `${API_GROUP}/owner`,
@@ -85,6 +91,8 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
   k8sNamespace: string = '';
   // The filter for entities that are allowed to be uploaded
   filter: EntityFilter;
+  // Caps how many ServiceModel API requests are in flight at once
+  private readonly semaphore = new Semaphore(MAX_CONCURRENT_K8S_REQUESTS);
 
   /**
    * fromComfig creates a new GrafanaServiceModelProcessor from the config
@@ -429,11 +437,25 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
   }
 
   /**
-   * createOrUpdateModel creates or updates the entity in the GrafanaServiceModel
+   * createOrUpdateModel creates or updates the entity in the GrafanaServiceModel,
+   * waiting for a free request slot first.
    * @param entity - The entity to create or update in the GrafanaServiceModel
    * @returns - A promise that resolves to true if the entity was created or updated, false otherwise
    */
   async createOrUpdateModel(entity: Entity): Promise<boolean> {
+    // The slot is held until the whole upload settles, so no more than
+    // MAX_CONCURRENT_K8S_REQUESTS uploads are ever in flight.
+    return this.semaphore.run(() => this.uploadModel(entity));
+  }
+
+  /**
+   * uploadModel gets, then creates or replaces, the entity's model in the
+   * GrafanaServiceModel. Callers should go through createOrUpdateModel so that
+   * the concurrency limit is applied.
+   * @param entity - The entity to upload
+   * @returns - A promise that resolves to true if the entity was created or updated, false otherwise
+   */
+  private async uploadModel(entity: Entity): Promise<boolean> {
     // This is where we convert the Backstage entity to the GrafanaServiceModel makeing any
     // shape changes needed to conform to the GrafanaServiceModel API
     const model: KubernetesObjectWithSpec = entityToServiceModel(

--- a/src/semaphore.test.ts
+++ b/src/semaphore.test.ts
@@ -1,0 +1,141 @@
+import { Semaphore } from './semaphore';
+
+// A promise with an externally controlled settle time, so tests can hold tasks
+// open and decide exactly when they finish.
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const tick = () => new Promise(resolve => setImmediate(resolve));
+
+describe('Semaphore', () => {
+  it('rejects a nonsensical limit', () => {
+    expect(() => new Semaphore(0)).toThrow(/positive integer/);
+    expect(() => new Semaphore(-1)).toThrow(/positive integer/);
+    expect(() => new Semaphore(1.5)).toThrow(/positive integer/);
+  });
+
+  it('holds the slot until the task settles, not until it starts', async () => {
+    const sem = new Semaphore(1);
+    const first = deferred();
+    let secondStarted = false;
+
+    const firstRun = sem.run(() => first.promise);
+    const secondRun = sem.run(async () => {
+      secondStarted = true;
+    });
+
+    // The first task is still pending, so the second must not have begun. This
+    // is the case that breaks if the slot is freed when the task's promise is
+    // created rather than when it settles.
+    await tick();
+    expect(secondStarted).toBe(false);
+
+    first.resolve();
+    await Promise.all([firstRun, secondRun]);
+    expect(secondStarted).toBe(true);
+  });
+
+  it('never runs more than maxConcurrency tasks at once', async () => {
+    const sem = new Semaphore(3);
+    let active = 0;
+    let peak = 0;
+
+    await Promise.all(
+      Array.from({ length: 30 }, () =>
+        sem.run(async () => {
+          active++;
+          peak = Math.max(peak, active);
+          await tick();
+          active--;
+        }),
+      ),
+    );
+
+    expect(peak).toBe(3);
+    expect(active).toBe(0);
+  });
+
+  it('lets waiting tasks through in the order they arrived', async () => {
+    const sem = new Semaphore(1);
+    const blocker = deferred();
+    const order: number[] = [];
+
+    const runs = [
+      sem.run(() => blocker.promise),
+      ...[1, 2, 3, 4].map(n =>
+        sem.run(async () => {
+          order.push(n);
+        }),
+      ),
+    ];
+
+    blocker.resolve();
+    await Promise.all(runs);
+
+    expect(order).toEqual([1, 2, 3, 4]);
+  });
+
+  it('frees the slot when a task rejects', async () => {
+    const sem = new Semaphore(1);
+
+    await expect(
+      sem.run(() => Promise.reject(new Error('task blew up'))),
+    ).rejects.toThrow('task blew up');
+
+    // A leaked slot would leave the semaphore permanently full
+    await expect(sem.run(async () => 'still works')).resolves.toBe(
+      'still works',
+    );
+  });
+
+  it('frees the slot when a task throws synchronously', async () => {
+    const sem = new Semaphore(1);
+
+    await expect(
+      sem.run(() => {
+        throw new Error('threw before returning');
+      }),
+    ).rejects.toThrow('threw before returning');
+
+    await expect(sem.run(async () => 'still works')).resolves.toBe(
+      'still works',
+    );
+  });
+
+  it('passes the task result through', async () => {
+    const sem = new Semaphore(2);
+
+    await expect(sem.run(async () => 42)).resolves.toBe(42);
+  });
+
+  it('keeps its limit across successive batches', async () => {
+    const sem = new Semaphore(2);
+    let peak = 0;
+    let active = 0;
+
+    const batch = () =>
+      Promise.all(
+        Array.from({ length: 5 }, () =>
+          sem.run(async () => {
+            active++;
+            peak = Math.max(peak, active);
+            await tick();
+            active--;
+          }),
+        ),
+      );
+
+    await batch();
+    await batch();
+
+    expect(peak).toBe(2);
+    expect(active).toBe(0);
+  });
+});

--- a/src/semaphore.ts
+++ b/src/semaphore.ts
@@ -1,0 +1,64 @@
+/**
+ * Semaphore bounds how many tasks may run at the same time. Tasks beyond the
+ * limit wait for a slot, in the order they asked for one.
+ *
+ * run() is the only way in. Acquiring and releasing are private because
+ * pairing them by hand is easy to get wrong: in an async function,
+ *
+ *   try { return somePromise } finally { release() }
+ *
+ * releases the slot as soon as somePromise is *created*, not when it settles,
+ * which silently removes all throttling.
+ */
+export class Semaphore {
+  // Resolvers for callers waiting on a slot, oldest first
+  private readonly waiting: Array<() => void> = [];
+  // Number of slots currently held
+  private inFlight: number = 0;
+
+  constructor(private readonly maxConcurrency: number) {
+    if (!Number.isInteger(maxConcurrency) || maxConcurrency < 1) {
+      throw new Error(
+        `Semaphore: maxConcurrency must be a positive integer, got ${maxConcurrency}`,
+      );
+    }
+  }
+
+  /**
+   * run waits for a free slot, runs the task, and frees the slot once the task
+   * settles, whether it resolves or rejects.
+   * @param task - The work to run while holding a slot
+   * @returns - Whatever the task resolves to
+   */
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    await this.acquire();
+    try {
+      // `return await` is load-bearing. A bare `return` would run the finally
+      // block as soon as the task's promise is created.
+      return await task();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.inFlight < this.maxConcurrency) {
+      this.inFlight++;
+      return Promise.resolve();
+    }
+    return new Promise<void>(resolve => {
+      this.waiting.push(resolve);
+    });
+  }
+
+  private release(): void {
+    // Hand the slot directly to the next waiter instead of decrementing and
+    // letting it re-acquire, so inFlight never dips and no waiter is skipped.
+    const next = this.waiting.shift();
+    if (next) {
+      next();
+      return;
+    }
+    this.inFlight--;
+  }
+}


### PR DESCRIPTION
**Stack 3/6.** Base: #186. See #185 for why the upstream branch contents do not match their PR descriptions.

Closes #164.

The catalog does not wait for `postProcessEntity`'s upload, so in a large catalog every entity's K8s request starts at once. That triggers rate limiting and entities get dropped. A semaphore now caps in-flight uploads at 10.

## The upstream version had no throttling effect whatsoever

It wrapped the upload as:

```ts
await this.semaphore.acquire();
try {
  return this.getModel(entity).then(...)   // <- evaluated, not awaited
} finally {
  this.semaphore.release();
}
```

In an async function the `finally` block runs when the return **expression is evaluated**, not when the returned promise settles. So the sequence was `acquire()` → fire the request → `release()`, all before a single byte came back. Concurrency stayed unbounded; the semaphore added one microtask of delay.

Fixed with `return await`. Four of the new tests fail if it is reduced to a bare `return` — verified by making that edit.

Upstream's own tests could not catch this because they only exercised the `Semaphore` class in isolation, never the call site. Their max-concurrency test awaited three sequential `acquire()` calls on a `Semaphore(3)` and asserted the push order `[1,2,3]` — which passes for any limit, including 1.

## Other changes from upstream

- **`run()` is now the only entry point**, with `acquire`/`release` private. The pairing that upstream got wrong on its single call site is structural rather than a convention every caller must honour.
- **Counter corruption.** Upstream's `release()` did `this.running--` unconditionally, so a release without a matching acquire drove the count negative and permanently raised the effective limit. Its test asserted only `expect(() => sem.release()).not.toThrow()` — which passes while the object silently corrupts itself. With `run()` as the sole entry the pairing is guaranteed, so no defensive clamp is needed.
- `release()` hands the slot straight to the next waiter instead of decrementing and letting it re-acquire, so `inFlight` never dips and no waiter is skipped.
- The constructor rejects a non-positive or fractional limit, rather than accepting a semaphore that either blocks forever or admits everyone.
- **Extracted the upload body to a private `uploadModel()`** instead of wrapping 90 lines in a `try` without re-indenting them, which is what made upstream's diff misaligned and lint-dirty.
- **Rewrote the tests** to measure peak concurrency, and added a processor-level test driving 50 entities through `createOrUpdateModel` asserting the peak is exactly 10.

## Follow-ups filed

- **#176** — fixed later in this stack. Failed uploads are cached as though they succeeded, which makes any single transient failure permanent. Probably a bigger contributor to the dropped-entity symptom this PR targets than rate limiting is.
- **#177** — a 429 is still logged and swallowed with no retry, and `Retry-After` is ignored. Note a concurrency cap is not a rate limit: ten concurrent requests at 5ms each is 2000 req/s.
- **#178** — the limit is hardcoded at 10 and should be config.
- **#179** — queue depth is unobservable. Partly addressed by the backpressure in #176 and the timeout at the end of this stack.

## Verification

`yarn tsc`, `yarn lint`, `yarn build`, `yarn test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Stack

| | PR | Base |
|---|---|---|
| 1/6 | #185 — backoff (#162) | `main` |
| 2/6 | #186 — sanitize logs + GCOM timeout (#163) | #185 |
| 3/6 | #187 — concurrency cap (#164) | #186 |
| 4/6 | #188 — constructor catch + name validation (#165) | #187 |
| 5/6 | #189 — cache only on success (#176) | #188 |
| 6/6 | #190 — 30s K8s request timeout | #189 |

Merge in order. Each PR needs its predecessor merged first, or GitHub will show the predecessor's commits in its diff.
