### PR TITLE
fix: catch constructor rejection and validate entity names (#165) [4/6]

### DIFF
--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -6,9 +6,11 @@ import {
   CatalogProcessorCache,
   CatalogProcessorEmit,
 } from '@backstage/plugin-catalog-node';
+import { makeValidator } from '@backstage/catalog-model';
 import {
   GrafanaServiceModelProcessor,
   entityToServiceModel,
+  isValidK8sObjectName,
   KubernetesObjectWithSpec,
 } from './processor';
 
@@ -194,33 +196,76 @@ describe('config absent', () => {
   });
 });
 
-describe('entity name validation', () => {
-  const nameRegex = /^[a-z0-9][a-z0-9\-.]*[a-z0-9]$/;
-
-  it('should accept valid K8s names', () => {
-    expect(nameRegex.test('my-service')).toBe(true);
-    expect(nameRegex.test('telemetry-gateway')).toBe(true);
-    expect(nameRegex.test('sqm-ingestor-kafka')).toBe(true);
-    expect(nameRegex.test('a1')).toBe(true);
-    expect(nameRegex.test('service.name.with.dots')).toBe(true);
+describe('isValidK8sObjectName', () => {
+  it.each([
+    ['an ordinary name', 'my-service'],
+    ['dot-separated labels', 'service.name.with.dots'],
+    ['two characters', 'a1'],
+    ['a single character', 'a'],
+    ['a single digit', '7'],
+    ['a label at its 63 char limit', 'a'.repeat(63)],
+    ['several labels at their limit', `${'a'.repeat(63)}.${'b'.repeat(63)}`],
+    // 63 chars, a dot, three times over, then 61 more: 253 exactly
+    [
+      'exactly the 253 char total limit',
+      `${'a'.repeat(63)}.`.repeat(3) + 'a'.repeat(61),
+    ],
+  ])('accepts %s', (_description, name) => {
+    expect(name.length).toBeLessThanOrEqual(253);
+    expect(isValidK8sObjectName(name)).toBe(true);
   });
 
-  it('should reject invalid K8s names', () => {
-    expect(nameRegex.test('')).toBe(false);
-    expect(nameRegex.test('-starts-with-dash')).toBe(false);
-    expect(nameRegex.test('ends-with-dash-')).toBe(false);
-    expect(nameRegex.test('.starts-with-dot')).toBe(false);
-    expect(nameRegex.test('has spaces')).toBe(false);
-    expect(nameRegex.test('HAS-UPPERCASE')).toBe(false);
-    expect(nameRegex.test('../../admin')).toBe(false);
-    expect(nameRegex.test('foo/bar')).toBe(false);
-    expect(nameRegex.test('a')).toBe(false); // single char - needs start AND end
+  it.each([
+    ['an empty name', ''],
+    ['a leading dash', '-starts-with-dash'],
+    ['a trailing dash', 'ends-with-dash-'],
+    ['a leading dot', '.starts-with-dot'],
+    ['a trailing dot', 'ends-with-dot.'],
+    ['an empty label between dots', 'a..b'],
+    ['a label starting with a dash', 'a.-b'],
+    ['a space', 'has spaces'],
+    ['a path separator', 'foo/bar'],
+    ['path traversal', '../../admin'],
+    ['one char over the 253 char total', 'a'.repeat(254)],
+    // Under the 253 total, but the first label is over its own 63 char limit
+    ['a label one char over its 63 char limit', `${'a'.repeat(64)}.b`],
+  ])('rejects %s', (_description, name) => {
+    expect(isValidK8sObjectName(name)).toBe(false);
   });
 
-  it('should reject names longer than 253 characters', () => {
-    const longName = 'a'.repeat(254);
-    expect(longName.length > 253).toBe(true);
-    // The regex itself doesn't check length, but the code does
+  // Backstage validates entity names with the Kubernetes *label value* rules,
+  // which are looser than the object name rules the ServiceModel API applies.
+  // These names are legal in Backstage and illegal as object names, which is
+  // the entire reason this check exists.
+  it.each([
+    ['HAS-UPPERCASE', 'uppercase letters'],
+    ['My-Service', 'mixed case'],
+    ['has_underscore', 'an underscore'],
+  ])('rejects %j, which Backstage allows (%s)', name => {
+    expect(isValidK8sObjectName(name)).toBe(false);
+  });
+
+  // Asserted against Backstage's own validator rather than a copy of its regex,
+  // so that if Backstage ever tightens entity names to match Kubernetes object
+  // names, this fails and the check above can be dropped.
+  it('disagrees with Backstage only where Kubernetes is stricter', () => {
+    const { isValidEntityName } = makeValidator();
+
+    for (const name of [
+      'HAS-UPPERCASE',
+      'My-Service',
+      'has_underscore',
+      'a..b',
+    ]) {
+      expect(isValidEntityName(name)).toBe(true);
+      expect(isValidK8sObjectName(name)).toBe(false);
+    }
+
+    // And agrees everywhere else, single characters included
+    for (const name of ['a', '7', 'my-service', 'service.name.with.dots']) {
+      expect(isValidEntityName(name)).toBe(true);
+      expect(isValidK8sObjectName(name)).toBe(true);
+    }
   });
 });
 
@@ -365,6 +410,123 @@ describe('connection backoff', () => {
     expect(logger.info).not.toHaveBeenCalledWith(
       'GrafanaServiceModelProcessor: Connection restored.',
     );
+  });
+
+  it('logs and stays disabled when the startup connection throws', async () => {
+    // A constructor cannot await, so an uncaught rejection here would surface as
+    // an unhandled rejection and take the backend down.
+    connect.mockRejectedValue(new Error('TLS handshake failed'));
+
+    const processor = await newProcessor();
+
+    expect(processor.grafanaAvailable).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('TLS handshake failed'),
+    );
+    // and it still counts as a failure, so the backoff starts where it should
+    expect(lastRetrySeconds()).toBe(60);
+  });
+
+  it('keeps processing entities after the startup connection throws', async () => {
+    connect.mockRejectedValue(new Error('TLS handshake failed'));
+    const processor = await newProcessor();
+
+    await expect(process(processor)).resolves.toBe(entity);
+  });
+});
+
+describe('entities with unusable names', () => {
+  const CONFIG = {
+    grafanaCloudCatalogInfo: {
+      enable: true,
+      stack_slug: 'dev',
+      grafana_endpoint: 'https://grafana-dev.com',
+      token: 'token',
+      allow: ['kind=Component,spec.type=service'],
+    },
+  };
+
+  let logger: jest.Mocked<LoggerService>;
+  let processor: GrafanaServiceModelProcessor;
+
+  beforeEach(() => {
+    logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn(),
+    } as unknown as jest.Mocked<LoggerService>;
+
+    jest
+      .spyOn(
+        GrafanaServiceModelProcessor.prototype,
+        'createAndTestGrafanaConnection',
+      )
+      .mockResolvedValue(true);
+
+    processor = GrafanaServiceModelProcessor.fromConfig({
+      logger,
+      config: new ConfigReader(CONFIG) as Config,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function componentNamed(name: string): Entity {
+    return {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name },
+      spec: { type: 'service' },
+    };
+  }
+
+  it('skips the entity without calling the API', async () => {
+    const getModel = jest.spyOn(processor, 'getModel');
+
+    await expect(
+      processor.createOrUpdateModel(componentNamed('Has-Uppercase')),
+    ).resolves.toBe(false);
+
+    expect(getModel).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Has-Uppercase'),
+    );
+  });
+
+  it('warns once per name, not once per catalog cycle', async () => {
+    jest.spyOn(processor, 'getModel');
+
+    for (let cycle = 0; cycle < 20; cycle++) {
+      await processor.createOrUpdateModel(componentNamed('Has-Uppercase'));
+    }
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns separately for each distinct unusable name', async () => {
+    await processor.createOrUpdateModel(componentNamed('Has-Uppercase'));
+    await processor.createOrUpdateModel(componentNamed('has_underscore'));
+
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('still uploads entities whose names are fine', async () => {
+    const getModel = jest
+      .spyOn(processor, 'getModel')
+      .mockImplementation(async (entity: Entity) =>
+        entityToServiceModel(entity, '', ''),
+      );
+
+    await expect(
+      processor.createOrUpdateModel(componentNamed('a')),
+    ).resolves.toBe(true);
+
+    expect(getModel).toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });
 

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -43,6 +43,23 @@ const BACKOFF_MAX_MS = 3_600_000;
 // so we do not get rate limited by the ServiceModel API.
 const MAX_CONCURRENT_K8S_REQUESTS = 10;
 
+// A Kubernetes object name must be an RFC 1123 DNS subdomain: up to 253 chars
+// of dot-separated DNS labels, each at most 63 chars of lowercase alphanumerics
+// and dashes, starting and ending alphanumeric.
+//
+// Backstage's own entity name rule is looser. isValidEntityName in
+// @backstage/catalog-model is isValidObjectName:
+//
+//   value.length >= 1 && value.length <= 63 &&
+//   /^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$/.test(value)
+//
+// which follows the Kubernetes *label value* rules, not the object name rules.
+// So a name Backstage accepts can still be illegal here in three ways:
+// uppercase letters, underscores, and empty dot-separated segments ('a..b').
+const MAX_OBJECT_NAME_LENGTH = 253;
+const MAX_DNS_LABEL_LENGTH = 63;
+const DNS_LABEL = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
 const LABELS = {
   OWNER: `${API_GROUP}/owner`,
   SYSTEM: `${API_GROUP}/system`,
@@ -93,6 +110,8 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
   filter: EntityFilter;
   // Caps how many ServiceModel API requests are in flight at once
   private readonly semaphore = new Semaphore(MAX_CONCURRENT_K8S_REQUESTS);
+  // Entity names already reported as unusable, so each is only logged once
+  private readonly warnedAboutNames = new Set<string>();
 
   /**
    * fromComfig creates a new GrafanaServiceModelProcessor from the config
@@ -158,10 +177,23 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
     }
 
     this.lastConnectionAttempt = new Date();
-    this.createAndTestGrafanaConnection().then(result => {
-      this.grafanaAvailable = result;
-      this.recordConnectionResult(result);
-    });
+    this.createAndTestGrafanaConnection()
+      .then(result => {
+        this.grafanaAvailable = result;
+        this.recordConnectionResult(result);
+      })
+      .catch(error => {
+        // A constructor cannot await, so without this catch a rejection here is
+        // an unhandled rejection, which terminates the backend by default in
+        // Node 16 and later.
+        this.logger.error(
+          `GrafanaServiceModelProcessor: Initial connection attempt threw: ${
+            error?.message || String(error)
+          }`,
+        );
+        this.grafanaAvailable = false;
+        this.recordConnectionResult(false);
+      });
   }
 
   /**
@@ -443,9 +475,34 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
    * @returns - A promise that resolves to true if the entity was created or updated, false otherwise
    */
   async createOrUpdateModel(entity: Entity): Promise<boolean> {
+    // Checked before taking a slot, since a name we will not send is not worth
+    // queueing behind the entities we will.
+    if (!isValidK8sObjectName(entity.metadata.name)) {
+      this.warnOnceAboutName(entity);
+      return false;
+    }
+
     // The slot is held until the whole upload settles, so no more than
     // MAX_CONCURRENT_K8S_REQUESTS uploads are ever in flight.
     return this.semaphore.run(() => this.uploadModel(entity));
+  }
+
+  /**
+   * warnOnceAboutName reports an entity whose name cannot be used as a
+   * Kubernetes object name. Only the first sighting of each name is logged:
+   * every catalog cycle revisits the same entities, so warning each time would
+   * be the same log flood the reconnect backoff exists to avoid.
+   * @param entity - The entity being skipped
+   */
+  private warnOnceAboutName(entity: Entity): void {
+    if (this.warnedAboutNames.has(entity.metadata.name)) {
+      return;
+    }
+    this.warnedAboutNames.add(entity.metadata.name);
+
+    this.logger.warn(
+      `GrafanaServiceModelProcessor: Skipping ${entity.kind} '${entity.metadata.name}': the name is not a valid Kubernetes object name, so the ServiceModel API would reject it. Names may only contain lowercase letters, digits, '-' and '.', and must start and end with a letter or digit. Backstage permits uppercase letters and underscores in entity names, Kubernetes does not.`,
+    );
   }
 
   /**
@@ -699,6 +756,25 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
 
 function pluralize(s: string): string {
   return `${s.toLowerCase()}s`;
+}
+
+/**
+ * isValidK8sObjectName reports whether a name can be used as a Kubernetes
+ * object name, and so whether it is safe to put in a ServiceModel API path.
+ * Note that a single character is a valid name.
+ * @param name - The name to check, normally entity.metadata.name
+ * @returns - True if the name is a valid RFC 1123 DNS subdomain
+ */
+export function isValidK8sObjectName(name: string): boolean {
+  if (name.length === 0 || name.length > MAX_OBJECT_NAME_LENGTH) {
+    return false;
+  }
+
+  return name
+    .split('.')
+    .every(
+      label => label.length <= MAX_DNS_LABEL_LENGTH && DNS_LABEL.test(label),
+    );
 }
 
 // According to the k8s spec for labels:


### PR DESCRIPTION
**Stack 4/6.** Base: #187. See #185 for why the upstream branch contents do not match their PR descriptions.

Closes #165.

Two safety issues.

## Unhandled rejection in the constructor

`createAndTestGrafanaConnection()` was called with a `.then()` but no `.catch()`. A constructor cannot await, so a rejection there is an unhandled rejection, which by default terminates the process in Node 16 and later. Now logged, with `grafanaAvailable` set false and the failure recorded through the same backoff accounting as any other.

## Entity name validation

`entity.metadata.name` goes straight into ServiceModel API paths. Names are now checked before any request is made, and before a concurrency slot is taken — a name we will not send is not worth queueing behind entities we will.

### The single-character bug

Upstream's regex `/^[a-z0-9][a-z0-9\-.]*[a-z0-9]$/` **rejects every single-character name**, because two anchored character classes cannot both match one character. `a` and `7` are valid in both Backstage and Kubernetes, so this silently skipped legitimate entities — and its test asserted the rejection as intended behaviour:

```js
expect(nameRegex.test('a')).toBe(false); // single char - needs start AND end
```

### Replaced with a real DNS subdomain check

Upstream also accepted `a..b` and `a.-b`, which the API rejects, and applied the 253-char limit to the whole name while ignoring the per-label 63-char limit. Now validates each dot-separated label at ≤63 and the whole name at ≤253.

## What Backstage actually allows in `entity.metadata.name`

Worth stating, since the value of this check depends on it. `makeValidator().isValidEntityName` in `@backstage/catalog-model` is `isValidObjectName`:

```js
value.length >= 1 && value.length <= 63 &&
/^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$/.test(value)
```

That follows the Kubernetes **label value** rules, not the **object name** rules, despite the function's name — it is reused for `isValidLabelValue` in the same file.

| | Backstage entity name | K8s object name (RFC 1123 subdomain) |
|---|---|---|
| Length | 1–63 | 1–253, each dot-label ≤63 |
| Case | `A-Z` **and** `a-z` | lowercase only |
| Separators | `-` `_` `.` | `-` `.` only |
| Empty labels | `a..b` allowed | rejected |

So three classes of name are legal in Backstage and illegal as an object name: **uppercase letters**, **underscores**, and **empty dot-segments**. Everything else Backstage accepts is a valid object name — the 63-char cap makes the 253 limit unreachable via Backstage. The practical set of affected names is `My-Service` / `my_service` style.

There is a test asserting this divergence via **Backstage's own `makeValidator()`** rather than a copy of its regex, so it fails if Backstage ever tightens entity names to match object names, at which point this check can be deleted.

## Other changes from upstream

- **Each unusable name is warned about once**, not once per catalog cycle. Every cycle revisits every entity, so a catalog with a few hundred uppercase names would emit tens of thousands of warnings a day — the same log flood the backoff in #162 exists to prevent.
- The warning explains what is wrong and that Backstage is looser than Kubernetes here, rather than just naming the entity.
- **Replaced the vestigial test block** that #160 left in `processor.test.ts`. It tested a regex literal declared in the test file, not any production code, so it passed regardless of behaviour. Now tested against the real function as a table.

## Filed, not fixed: #181

The `.catch()` does not fully close the hole. `createAndTestGrafanaConnection` has the **same** async `try`/`finally` defect as the semaphore in #164 — `isConnecting = false` runs in the same tick it is set, so the "lock to prevent multiple simultaneous connection attempts" prevents nothing. Worse, its body is `new Promise(async (resolve) => …)` with `makeApiClient` outside both inner `try` blocks: if that throws, the promise **never settles at all**, so no `.catch()` can observe it and any awaiting caller hangs forever.

Left out because it is a larger rewrite than this PR covers and it is in the one method no test can currently reach (#175). That the same async-`finally` mistake appears twice independently in this file suggests a lint rule rather than another one-off fix.

## Verification

`yarn tsc`, `yarn lint`, `yarn build`, `yarn test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Stack

| | PR | Base |
|---|---|---|
| 1/6 | #185 — backoff (#162) | `main` |
| 2/6 | #186 — sanitize logs + GCOM timeout (#163) | #185 |
| 3/6 | #187 — concurrency cap (#164) | #186 |
| 4/6 | #188 — constructor catch + name validation (#165) | #187 |
| 5/6 | #189 — cache only on success (#176) | #188 |
| 6/6 | #190 — 30s K8s request timeout | #189 |

Merge in order. Each PR needs its predecessor merged first, or GitHub will show the predecessor's commits in its diff.
