### PR TITLE
fix: only cache an entity once its upload has succeeded (#176, #166) [5/6]

### DIFF
--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -530,6 +530,211 @@ describe('entities with unusable names', () => {
   });
 });
 
+describe('caching uploads', () => {
+  const CONFIG = {
+    grafanaCloudCatalogInfo: {
+      enable: true,
+      stack_slug: 'dev',
+      grafana_endpoint: 'https://grafana-dev.com',
+      token: 'token',
+      allow: ['kind=Component,spec.type=service'],
+    },
+  };
+
+  const entity: Entity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'my-service' },
+    spec: { type: 'service' },
+  };
+
+  let logger: jest.Mocked<LoggerService>;
+  let processor: GrafanaServiceModelProcessor;
+  let upload: jest.SpyInstance<Promise<boolean>, [Entity]>;
+
+  // Stands in for the catalog's per-entity processing cache. The catalog only
+  // persists a new state when it differs from the one it passed in, so "never
+  // written" and "written with the same value" both keep the stored copy.
+  let stored: Entity | undefined;
+  let cache: CatalogProcessorCache;
+  let writes: number;
+
+  beforeEach(() => {
+    logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn(),
+    } as unknown as jest.Mocked<LoggerService>;
+
+    stored = undefined;
+    writes = 0;
+    cache = {
+      get: jest.fn(async () => stored),
+      set: jest.fn(async (_key: string, value: any) => {
+        stored = value;
+        writes++;
+      }),
+    } as unknown as CatalogProcessorCache;
+
+    jest
+      .spyOn(
+        GrafanaServiceModelProcessor.prototype,
+        'createAndTestGrafanaConnection',
+      )
+      .mockResolvedValue(true);
+
+    processor = GrafanaServiceModelProcessor.fromConfig({
+      logger,
+      config: new ConfigReader(CONFIG) as Config,
+    });
+    processor.grafanaAvailable = true;
+
+    upload = jest.spyOn(processor, 'createOrUpdateModel');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const process = () =>
+    processor.postProcessEntity!(
+      entity,
+      {} as LocationSpec,
+      jest.fn() as CatalogProcessorEmit,
+      cache,
+    );
+
+  it('caches the entity once the upload succeeds', async () => {
+    upload.mockResolvedValue(true);
+
+    await expect(process()).resolves.toBe(entity);
+
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(stored).toEqual(entity);
+  });
+
+  it('does not cache the entity when the upload reports failure', async () => {
+    upload.mockResolvedValue(false);
+
+    await expect(process()).resolves.toBe(entity);
+
+    expect(stored).toBeUndefined();
+    expect(writes).toBe(0);
+  });
+
+  it('does not cache the entity when the upload throws', async () => {
+    upload.mockRejectedValue(new Error('429 Too Many Requests'));
+
+    await expect(process()).resolves.toBe(entity);
+
+    expect(stored).toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('429 Too Many Requests'),
+      expect.anything(),
+    );
+  });
+
+  it('retries on the next cycle after a failure, then caches on success', async () => {
+    upload.mockResolvedValue(false);
+    await process();
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    // Nothing was cached, so the next cycle tries again rather than skipping
+    await process();
+    expect(upload).toHaveBeenCalledTimes(2);
+
+    upload.mockResolvedValue(true);
+    await process();
+    expect(upload).toHaveBeenCalledTimes(3);
+    expect(stored).toEqual(entity);
+
+    // And now it stops re-uploading
+    await process();
+    expect(upload).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not touch the cache when the entity is unchanged', async () => {
+    upload.mockResolvedValue(true);
+    await process();
+    expect(writes).toBe(1);
+
+    await process();
+    await process();
+
+    // No further uploads, and no rewrites: leaving the key alone is what keeps
+    // the stored copy, so there is nothing to re-set.
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(writes).toBe(1);
+  });
+
+  it('re-uploads when the entity has changed since it was cached', async () => {
+    upload.mockResolvedValue(true);
+    await process();
+    expect(upload).toHaveBeenCalledTimes(1);
+
+    stored = { ...entity, spec: { type: 'service', owner: 'someone-else' } };
+    await process();
+
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(stored).toEqual(entity);
+  });
+
+  // Credit to #166, which spotted that an unreadable cache hangs the entity.
+  it('treats an unreadable cache as a miss instead of hanging', async () => {
+    upload.mockResolvedValue(true);
+    cache.get = jest.fn().mockRejectedValue(new Error('cache backend down'));
+
+    // Without handling, the rejection leaves postProcessEntity pending forever
+    await expect(process()).resolves.toBe(entity);
+
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('cache backend down'),
+    );
+  });
+
+  it('survives a cache write failure after a successful upload', async () => {
+    upload.mockResolvedValue(true);
+    cache.set = jest.fn().mockRejectedValue(new Error('cache write failed'));
+
+    await expect(process()).resolves.toBe(entity);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('cache write failed'),
+    );
+  });
+
+  it('waits for the upload before resolving', async () => {
+    let finishUpload!: (value: boolean) => void;
+    upload.mockImplementation(
+      () =>
+        new Promise<boolean>(resolve => {
+          finishUpload = resolve;
+        }),
+    );
+
+    let settled = false;
+    const processing = process().then(result => {
+      settled = true;
+      return result;
+    });
+
+    await new Promise(resolve => setImmediate(resolve));
+    // The catalog snapshots the cache as soon as this resolves, so resolving
+    // early would make the cache write below unpersistable.
+    expect(settled).toBe(false);
+    expect(stored).toBeUndefined();
+
+    finishUpload(true);
+    await processing;
+
+    expect(settled).toBe(true);
+    expect(stored).toEqual(entity);
+  });
+});
+
 describe('upload concurrency', () => {
   const CONFIG = {
     grafanaCloudCatalogInfo: {

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -412,58 +412,81 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         );
 
         const CACHE_KEY = stringifyEntityRef(entity);
-        cache.get(CACHE_KEY).then(cachedEntity => {
-          if (!cachedEntity) {
-            this.logger.debug(
-              `GrafanaServiceModelProcessor.postProcessEntity entity '${entity.kind}' with name '${entity.metadata.name}' not found in cache`,
-            );
-          } else if (!_.isEqual(entity, cachedEntity)) {
-            this.logger.debug(
-              `GrafanaServiceModelProcessor.postProcessEntity entity '${entity.kind}' with name '${entity.metadata.name}' differs from cached version`,
-            );
-          }
 
-          if (!cachedEntity || !_.isEqual(entity, cachedEntity)) {
-            this.createOrUpdateModel(entity)
-              .then(async result => {
-                if (result) {
-                  // Update the cache if we were successful in storing the model
-                  cache.set(CACHE_KEY, entity);
-                  // resolve(entity);
-                  // return;
-                }
-              })
-              .catch((err: any) => {
-                this.logger.error(
-                  `GrafanaServiceModelProcessor.postProcessEntity error: ${
-                    err.message || 'Unknown error'
-                  }`,
-                  {
-                    error: {
-                      name: err.name,
-                      message: err.message,
-                      stack: err.stack,
-                      ...(err instanceof Error ? {} : { details: err }),
-                    },
-                    entity: {
-                      kind: entity.kind,
-                      metadata: {
-                        name: entity.metadata.name,
-                        namespace: entity.metadata.namespace,
-                      },
-                    },
-                  },
-                );
-                // Eat the error, we don't want to stop the catalog from processing
-                // don't cache the entity, we will want to procees it again.
-              });
-          }
-          // The cache is ephemeral between invocations, so we need to add the entity to the cache
-          // on every invocation.
-          cache.set(CACHE_KEY, entity);
+        // An unhandled rejection here would leave this promise pending forever,
+        // stalling the entity rather than failing it. An unreadable cache is
+        // treated as a miss, which re-uploads; that is idempotent.
+        let cachedEntity: Entity | undefined;
+        try {
+          cachedEntity = await cache.get<Entity>(CACHE_KEY);
+        } catch (err: any) {
+          this.logger.warn(
+            `GrafanaServiceModelProcessor: Could not read the cache for ${CACHE_KEY}, treating it as a miss: ${
+              err?.message || String(err)
+            }`,
+          );
+        }
+
+        if (cachedEntity && _.isEqual(entity, cachedEntity)) {
+          // Already uploaded and unchanged. Writing nothing to the cache leaves
+          // the stored copy in place: the catalog only persists a new cache
+          // state when it differs from the one it handed us.
           resolve(entity);
           return;
-        });
+        }
+
+        this.logger.debug(
+          cachedEntity
+            ? `GrafanaServiceModelProcessor.postProcessEntity entity '${entity.kind}' with name '${entity.metadata.name}' differs from cached version`
+            : `GrafanaServiceModelProcessor.postProcessEntity entity '${entity.kind}' with name '${entity.metadata.name}' not found in cache`,
+        );
+
+        // Awaited deliberately. The catalog snapshots the cache as soon as this
+        // promise resolves, so a cache write from a still-running upload would
+        // arrive too late to be persisted.
+        let uploaded = false;
+        try {
+          uploaded = await this.createOrUpdateModel(entity);
+        } catch (err: any) {
+          this.logger.error(
+            `GrafanaServiceModelProcessor.postProcessEntity error: ${
+              err.message || 'Unknown error'
+            }`,
+            {
+              error: {
+                name: err.name,
+                message: err.message,
+                stack: err.stack,
+                ...(err instanceof Error ? {} : { details: err }),
+              },
+              entity: {
+                kind: entity.kind,
+                metadata: {
+                  name: entity.metadata.name,
+                  namespace: entity.metadata.namespace,
+                },
+              },
+            },
+          );
+          // Eat the error, we don't want to stop the catalog from processing.
+        }
+
+        if (uploaded) {
+          try {
+            await cache.set(CACHE_KEY, entity);
+          } catch (err: any) {
+            this.logger.warn(
+              `GrafanaServiceModelProcessor: Uploaded ${CACHE_KEY} but could not write the cache, so it will be uploaded again next cycle: ${
+                err?.message || String(err)
+              }`,
+            );
+          }
+        }
+        // On failure the cache is deliberately left alone, so this entity is
+        // tried again on the next cycle instead of being treated as uploaded.
+
+        resolve(entity);
+        return;
       }
     });
   }


### PR DESCRIPTION
**Stack 5/6.** Base: #188. This one is not from an upstream PR — it came out of reviewing #164.

Closes #176.

## The bug

`postProcessEntity` wrote the cache unconditionally, before the upload had finished:

```ts
if (!cachedEntity || !_.isEqual(entity, cachedEntity)) {
  this.createOrUpdateModel(entity)
    .then(async result => {
      if (result) {
        cache.set(CACHE_KEY, entity);   // dead: the line below already did it
      }
    })
    .catch(err => {
      this.logger.error(...);
      // don't cache the entity, we will want to process it again   <- not what happens
    });
}
cache.set(CACHE_KEY, entity);   // runs for every entity, success or not
resolve(entity);
```

So a failed upload was recorded as though it had succeeded. On the next cycle the entity compared equal to its cached copy and was skipped, leaving it missing from Grafana until it was next edited. **Any transient failure — a 429, a 500, a brief connection blip — dropped that entity permanently rather than being retried.**

Both guards around that line were dead: the `if (result)` never decided anything, and the `.catch` comment described the opposite of what happened.

The upload is now awaited, and the cache written only on success. On failure the key is left untouched so the next cycle retries.

## Why awaiting is required, not stylistic

The catalog snapshots the processing cache the moment `postProcessEntity` resolves, so a cache write issued from a still-running upload arrives after the snapshot and is never persisted. The unconditional write was the only reason caching worked at all.

## Cache semantics, verified against the catalog's own code

The comment being replaced — *"The cache is ephemeral between invocations, so we need to add the entity to the cache on every invocation"* — is incorrect. I ran the real `ProcessorCacheManager` through `DefaultCatalogProcessingEngine`'s exact comparison logic:

- **Not writing a key preserves it.** `SingleProcessorCache.collect()` returns `newState ?? existingState`, and the engine only calls `updateEntityCache` when the collected state differs from the state it passed in. Three consecutive no-set invocations gave `wrote=false` and the value survived intact. So skipping the write on failure correctly leaves the previous value (or nothing) in place.
- **The cache is not permanent either.** `CACHE_TTL = 5`: on any run where `result.ok === false` the engine decrements `ttl`, and at zero the next failed run replaces the whole state with `{}`. Walked it: 4→3→2→1→0, wiped on run 6. The trigger is the **entity's** processing reporting errors, not our upload failing — and this processor swallows its errors without emitting them to the collector, which is exactly why this bug was silent.
- **`set()` replaces rather than merges** — setting one key drops the others in that sub-cache. Moot here since the manager is built per entity and this processor writes one key, but a trap for anyone adding a second.

## Behaviour change worth a second opinion

Catalog processing now waits on the ServiceModel API. That is real backpressure rather than fire-and-forget, and it is the better of the two options #179 proposed — but it converts an invisible risk into a visible one:

- **Before:** a hung K8s request was invisible; the entity resolved immediately and the request leaked in the background.
- **After:** a hung request stalls that entity's processing and holds a concurrency slot for as long as it hangs. Ten would exhaust the cap from #164 and halt uploads.

**#189, the next PR in this stack, bounds every K8s request at 30s**, which closes that hole. If this merges without it, that risk is live.

## Tests

Seven new tests covering both directions: caches on success, does not cache on a `false` result, does not cache when the upload throws, retries on the next cycle after a failure then caches on success, does not rewrite when unchanged, re-uploads when the entity changed, and that the promise does not resolve until the upload settles. Restoring the unconditional write fails three of them — verified.

## Verification

`yarn tsc`, `yarn lint`, `yarn build`, `yarn test` all pass. The equivalent code passed the kind-based Integration job as #184, which is the check that exercises this against a real API server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Relationship to #166

**#166 by @Vanshul97 already reported and fixed this bug, three weeks before I filed #176.** I missed it when reviewing #162–#165. Two things follow from that:

**#166 caught a bug this PR had missed, now adopted with credit.** An unhandled rejection from `cache.get` leaves `postProcessEntity`'s promise permanently pending, so the entity stalls rather than fails — a distinct bug from the caching one, and the same async-executor hazard as #181. Both `cache.get` and `cache.set` rejections are now handled here, with a test for each; the test carries a comment crediting #166.

**One difference to resolve before either merges.** #166 caches on any non-throwing outcome, reading a `false` return as "already matches". It isn't: `createOrUpdateModel` returns `false` when `updateModel` **failed**, including on a 409 resourceVersion conflict — exactly the transient case a retry fixes. The unchanged path returns `true`. So #166 as written caches failed updates as synced, reintroducing the bug on the update path. This PR gates on the boolean.

Either approach can land; see my comment on #166. I don't want to steamroll it.

---

### Stack

| | PR | Base |
|---|---|---|
| 1/6 | #185 — backoff (#162) | `main` |
| 2/6 | #186 — sanitize logs + GCOM timeout (#163) | #185 |
| 3/6 | #187 — concurrency cap (#164) | #186 |
| 4/6 | #188 — constructor catch + name validation (#165) | #187 |
| 5/6 | #189 — cache only on success (#176) | #188 |
| 6/6 | #190 — 30s K8s request timeout | #189 |

Merge in order. Each PR needs its predecessor merged first, or GitHub will show the predecessor's commits in its diff.
