### PR TITLE
fix: bound every ServiceModel API request with a 30s timeout [6/6]

### DIFF
--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -11,6 +11,7 @@ import {
   GrafanaServiceModelProcessor,
   entityToServiceModel,
   isValidK8sObjectName,
+  requestTimeout,
   KubernetesObjectWithSpec,
 } from './processor';
 
@@ -527,6 +528,171 @@ describe('entities with unusable names', () => {
 
     expect(getModel).toHaveBeenCalled();
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('requestTimeout', () => {
+  // The real Observable is a bare promise wrapper, and the client is ESM only so
+  // it cannot be imported here. This matches its shape.
+  class FakeObservable<T> {
+    constructor(private readonly promise: Promise<T>) {}
+    toPromise(): Promise<T> {
+      return this.promise;
+    }
+  }
+
+  const build = (timeoutMs: number) =>
+    requestTimeout(FakeObservable as never, timeoutMs);
+
+  // Drives pre() the way the client does, returning the signal it installed
+  function signalFrom(options: ReturnType<typeof build>): AbortSignal {
+    const setSignal = jest.fn();
+    options.middleware![0].pre({ setSignal } as unknown as never);
+    expect(setSignal).toHaveBeenCalledTimes(1);
+    return setSignal.mock.calls[0][0];
+  }
+
+  it('installs an abort signal on the request', () => {
+    const signal = signalFrom(build(30_000));
+
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal.aborted).toBe(false);
+  });
+
+  it('aborts once the timeout elapses', async () => {
+    const signal = signalFrom(build(20));
+
+    await new Promise(resolve => setTimeout(resolve, 60));
+
+    expect(signal.aborted).toBe(true);
+    expect((signal.reason as Error).name).toBe('TimeoutError');
+  });
+
+  it('gives each request its own signal', () => {
+    const options = build(30_000);
+
+    const first = signalFrom(options);
+    const second = signalFrom(options);
+
+    // A signal shared across requests would abort every later request 30s after
+    // the first one started.
+    expect(first).not.toBe(second);
+  });
+
+  it('appends its middleware so the auth middleware survives', () => {
+    expect(build(30_000).middlewareMergeStrategy).toBe('append');
+  });
+
+  it('passes the request and response through untouched', async () => {
+    const options = build(30_000);
+    const request = { setSignal: jest.fn() };
+    const response = { status: 200 };
+
+    await expect(
+      (
+        options.middleware![0].pre(request as unknown as never) as any
+      ).toPromise(),
+    ).resolves.toBe(request);
+    await expect(
+      (
+        options.middleware![0].post(response as unknown as never) as any
+      ).toPromise(),
+    ).resolves.toBe(response);
+  });
+});
+
+describe('bounding ServiceModel API calls', () => {
+  const CONFIG = {
+    grafanaCloudCatalogInfo: {
+      enable: true,
+      stack_slug: 'dev',
+      grafana_endpoint: 'https://grafana-dev.com',
+      token: 'token',
+      allow: ['kind=Component,spec.type=service'],
+    },
+  };
+
+  const entity: Entity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'my-service' },
+    spec: { type: 'service' },
+  };
+
+  let processor: GrafanaServiceModelProcessor;
+  let client: {
+    getNamespacedCustomObject: jest.Mock;
+    replaceNamespacedCustomObject: jest.Mock;
+    createNamespacedCustomObject: jest.Mock;
+  };
+  const options = { middleware: [], middlewareMergeStrategy: 'append' };
+
+  beforeEach(() => {
+    jest
+      .spyOn(
+        GrafanaServiceModelProcessor.prototype,
+        'createAndTestGrafanaConnection',
+      )
+      .mockResolvedValue(true);
+
+    processor = GrafanaServiceModelProcessor.fromConfig({
+      logger: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+        child: jest.fn(),
+      } as unknown as LoggerService,
+      config: new ConfigReader(CONFIG) as Config,
+    });
+
+    client = {
+      getNamespacedCustomObject: jest.fn().mockResolvedValue({}),
+      replaceNamespacedCustomObject: jest.fn().mockResolvedValue({}),
+      createNamespacedCustomObject: jest.fn().mockResolvedValue({}),
+    };
+    processor.client = client as never;
+    processor.requestOptions = options as never;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('bounds getModel', async () => {
+    await processor.getModel(entity);
+
+    expect(client.getNamespacedCustomObject).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'my-service' }),
+      options,
+    );
+  });
+
+  it('bounds updateModel', async () => {
+    await processor.updateModel(entity, { metadata: {} });
+
+    expect(client.replaceNamespacedCustomObject).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'my-service' }),
+      options,
+    );
+  });
+
+  it('bounds both calls createModel can make', async () => {
+    // createModel reads first, and creates only if the read fails
+    client.getNamespacedCustomObject.mockRejectedValue(
+      Object.assign(new Error('not found'), { code: 404 }),
+    );
+
+    await processor.createModel(entity);
+
+    expect(client.getNamespacedCustomObject).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'my-service' }),
+      options,
+    );
+    expect(client.createNamespacedCustomObject).toHaveBeenCalledWith(
+      expect.objectContaining({ plural: 'components' }),
+      options,
+    );
   });
 });
 

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -1,7 +1,12 @@
 import type {
   KubeConfig,
+  ConfigurationOptions,
   CustomObjectsApi,
   KubernetesObject,
+  Observable,
+  ObservableMiddleware,
+  RequestContext,
+  ResponseContext,
   V1APIGroup,
   V1ObjectMeta,
 } from '@kubernetes/client-node';
@@ -42,6 +47,16 @@ const BACKOFF_MAX_MS = 3_600_000;
 // large catalog every entity's upload starts at once. Cap the in-flight requests
 // so we do not get rate limited by the ServiceModel API.
 const MAX_CONCURRENT_K8S_REQUESTS = 10;
+
+// The Kubernetes client applies no timeout of its own. Since postProcessEntity
+// waits for the upload, an unbounded request would stall that entity's catalog
+// processing and hold one of the MAX_CONCURRENT_K8S_REQUESTS slots for as long as
+// the socket stayed open. Ten such requests would stop uploads altogether.
+const K8S_REQUEST_TIMEOUT_MS = 30_000;
+
+// new k8s.Observable, which cannot be imported directly here: the client is an
+// ESM-only package, so this module can only reach it through a dynamic import.
+type ObservableConstructor = new <T>(promise: Promise<T>) => Observable<T>;
 
 // A Kubernetes object name must be an RFC 1123 DNS subdomain: up to 253 chars
 // of dot-separated DNS labels, each at most 63 chars of lowercase alphanumerics
@@ -108,6 +123,10 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
   k8sNamespace: string = '';
   // The filter for entities that are allowed to be uploaded
   filter: EntityFilter;
+  // Per-request options that bound every ServiceModel API call, set up alongside
+  // the client because both need the dynamically imported k8s module
+  requestOptions: ConfigurationOptions<ObservableMiddleware> | undefined =
+    undefined;
   // Caps how many ServiceModel API requests are in flight at once
   private readonly semaphore = new Semaphore(MAX_CONCURRENT_K8S_REQUESTS);
   // Entity names already reported as unusable, so each is only logged once
@@ -247,6 +266,8 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
     this.isConnecting = true;
     try {
       const k8s = await import('@kubernetes/client-node');
+      // Built here because this is the only place the ESM-only client is in scope
+      this.requestOptions = requestTimeout(k8s.Observable);
       return new Promise(async (resolve, _reject) => {
         if (!this.kc) {
           this.logger.debug(
@@ -282,7 +303,10 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         // Check if the ServiceModel API is available
         const apiApiClient = this.kc?.makeApiClient(k8s.ApisApi);
         try {
-          const response = await apiApiClient.getAPIVersions();
+          const response = await apiApiClient.getAPIVersions(
+            undefined,
+            this.requestOptions,
+          );
           this.logger.debug(
             `GrafanaServiceModelProcessor: API versions response: ${JSON.stringify(
               response,
@@ -644,13 +668,16 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
     }
 
     return this.client
-      .getNamespacedCustomObject({
-        group: API_GROUP,
-        version: this.serviceModelVersion,
-        namespace: this.k8sNamespace,
-        plural: pluralize(entity.kind),
-        name: entity.metadata.name,
-      })
+      .getNamespacedCustomObject(
+        {
+          group: API_GROUP,
+          version: this.serviceModelVersion,
+          namespace: this.k8sNamespace,
+          plural: pluralize(entity.kind),
+          name: entity.metadata.name,
+        },
+        this.requestOptions,
+      )
       .then((response: any) => {
         this.logger.debug(
           `GrafanaServiceModelProcessor.getModel response: ${JSON.stringify(
@@ -677,14 +704,17 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
     let k8sObject: KubernetesObjectWithSpec | undefined;
 
     return this.client
-      .replaceNamespacedCustomObject({
-        group: API_GROUP,
-        version: this.serviceModelVersion,
-        namespace: this.k8sNamespace,
-        plural: pluralize(entity.kind),
-        name: entity.metadata.name,
-        body: model,
-      })
+      .replaceNamespacedCustomObject(
+        {
+          group: API_GROUP,
+          version: this.serviceModelVersion,
+          namespace: this.k8sNamespace,
+          plural: pluralize(entity.kind),
+          name: entity.metadata.name,
+          body: model,
+        },
+        this.requestOptions,
+      )
       .then((response: any) => {
         k8sObject = response as KubernetesObjectWithSpec;
         this.logger.debug(
@@ -721,13 +751,16 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
 
     return (
       this.client
-        .getNamespacedCustomObject({
-          group: API_GROUP,
-          version: this.serviceModelVersion,
-          namespace: this.k8sNamespace,
-          plural: pluralize(entity.kind),
-          name: entity.metadata.name,
-        })
+        .getNamespacedCustomObject(
+          {
+            group: API_GROUP,
+            version: this.serviceModelVersion,
+            namespace: this.k8sNamespace,
+            plural: pluralize(entity.kind),
+            name: entity.metadata.name,
+          },
+          this.requestOptions,
+        )
         .then((response: any) => {
           k8sObject = response as KubernetesObjectWithSpec;
           this.logger.debug(
@@ -747,13 +780,16 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
             throw new Error('Kubernetes client not initialized');
           }
           return this.client
-            .createNamespacedCustomObject({
-              group: API_GROUP,
-              version: this.serviceModelVersion,
-              namespace: this.k8sNamespace,
-              plural: pluralize(entity.kind),
-              body: k8sModel,
-            })
+            .createNamespacedCustomObject(
+              {
+                group: API_GROUP,
+                version: this.serviceModelVersion,
+                namespace: this.k8sNamespace,
+                plural: pluralize(entity.kind),
+                body: k8sModel,
+              },
+              this.requestOptions,
+            )
             .then((response: any) => {
               k8sObject = response as KubernetesObjectWithSpec;
               this.logger.debug(
@@ -779,6 +815,40 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
 
 function pluralize(s: string): string {
   return `${s.toLowerCase()}s`;
+}
+
+/**
+ * requestTimeout builds the per-request options that bound a single ServiceModel
+ * API call. The client hands RequestContext's signal straight to node-fetch, so
+ * this aborts the request rather than merely abandoning it, which matters because
+ * an abandoned request would still hold its concurrency slot.
+ *
+ * A fresh signal is created per request, inside pre().
+ * @param ObservableCtor - The client's Observable, from the dynamic import
+ * @param timeoutMs - How long any one request may take
+ * @returns - Options to pass as the second argument to a client method
+ */
+export function requestTimeout(
+  ObservableCtor: ObservableConstructor,
+  timeoutMs: number = K8S_REQUEST_TIMEOUT_MS,
+): ConfigurationOptions<ObservableMiddleware> {
+  const passThrough = <T>(context: T): Observable<T> =>
+    new ObservableCtor(Promise.resolve(context));
+
+  const timeoutMiddleware: ObservableMiddleware = {
+    pre: (context: RequestContext) => {
+      context.setSignal(AbortSignal.timeout(timeoutMs));
+      return passThrough(context);
+    },
+    post: (context: ResponseContext) => passThrough(context),
+  };
+
+  return {
+    middleware: [timeoutMiddleware],
+    // Append rather than replace, so the auth middleware the KubeConfig installs
+    // is preserved.
+    middlewareMergeStrategy: 'append',
+  };
 }
 
 /**


### PR DESCRIPTION
**Stack 6/6.** Base: #189. Not from an upstream PR — this closes the risk that #189's backpressure introduces.

Refs #179.

## Why

The Kubernetes client applies no timeout of its own. That was survivable while uploads were fire-and-forget, but #189 makes `postProcessEntity` wait for the upload, so a hung request would stall that entity's catalog processing **and** hold one of the ten concurrency slots from #164 for as long as the socket stayed open. Ten hung requests would stop uploads altogether.

Every `CustomObjectsApi` call, and the `getAPIVersions` probe used to test the connection, now carries an `AbortSignal` that fires after 30s.

## This aborts rather than abandons

`@kubernetes/client-node` v1 has no timeout option, so I checked what it does support:

- `ConfigurationOptions` has no `signal` field — but `RequestContext.setSignal(signal: AbortSignal)` is public.
- `IsomorphicFetchHttpLibrary.send()` passes `signal: request.getSignal()` straight to `node-fetch`. So the signal is genuinely honoured.
- Per-request `ConfigurationOptions` accepts `middleware` plus a `middlewareMergeStrategy`, and the client ships its own `setHeaderMiddleware`/`setHeaderOptions` helpers using exactly this shape. This follows that pattern.
- The package re-exports `AbortError` from `node-fetch` at its root, which confirms an aborted request surfaces as a catchable error.

A `Promise.race` at the call site would have freed the concurrency slot while leaking the socket. This cancels the request.

`middlewareMergeStrategy: 'append'` so the auth middleware the `KubeConfig` installs is preserved rather than replaced.

## Implementation notes

- **A fresh signal is created inside `pre()` on every request.** Hoisting it would make one signal abort every later request 30s after the first one started. There is a test for that specifically.
- **The `Observable` wrapper is passed in rather than imported.** `@kubernetes/client-node` is ESM-only, so this module can only reach it through the dynamic import in `createAndTestGrafanaConnection` — which is also where `requestTimeout()` is called, alongside `makeApiClient`, so the options and the client are always built together. As a side benefit `requestTimeout` is testable without loading the client, which jest currently cannot do (#175).
- Everything is typed with public exports only: `ConfigurationOptions`, `ObservableMiddleware`, `RequestContext`, `ResponseContext` and `Observable` are all importable as types under this project's tsconfig, verified before writing the implementation.

## Tests

Eight new tests: the signal is installed; it aborts after the timeout with `reason.name === 'TimeoutError'`; each request gets its own signal; the merge strategy is `append`; request and response pass through untouched; and one per call site asserting `getModel`, `updateModel` and both of `createModel`'s calls forward the options.

## Not covered

The GCOM calls got their own 30s timeout in #186 via a different mechanism (`options.timeout` plus `req.destroy`), because those use `https.get` directly rather than the k8s client. Both are 30s, but they are deliberately separate constants in separate modules.

## Verification

`yarn tsc`, `yarn lint`, `yarn build`, `yarn test` all pass — 83 tests, up from 17 at the base of this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Stack

| | PR | Base |
|---|---|---|
| 1/6 | #185 — backoff (#162) | `main` |
| 2/6 | #186 — sanitize logs + GCOM timeout (#163) | #185 |
| 3/6 | #187 — concurrency cap (#164) | #186 |
| 4/6 | #188 — constructor catch + name validation (#165) | #187 |
| 5/6 | #189 — cache only on success (#176) | #188 |
| 6/6 | #190 — 30s K8s request timeout | #189 |

Merge in order. Each PR needs its predecessor merged first, or GitHub will show the predecessor's commits in its diff.
