### PR TITLE
feat: emit sync metrics for the ServiceModel processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ This work is very early. We are still exploring ways to utilize your Backstage C
 
 Follow the [quick start guide](docs/quickstart.md) to test this plugin with a new Backstage install. The instructions should carry over to your production install.
 
+## Metrics
+
+The processor emits metrics so you can tell whether a sync is healthy without
+reading logs. See [metrics](docs/metrics.md) for the full list and some example
+queries.
+
 ## Notes for developers
 
 To create a backstage instance and install this plugin for local development, run the following:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,31 +1,38 @@
 # Metrics
 
-The processor emits metrics through Backstage's [`MetricsService`][metrics-service],
-which is a facade over the OpenTelemetry meter API. The goal is that an operator
-can answer "did the last sync succeed?" from a dashboard, instead of grepping
-logs.
+The processor emits metrics through the [OpenTelemetry metrics API][otel-api], so
+that an operator can answer "did the last sync succeed?" from a dashboard instead
+of grepping logs.
 
 ## Setup
 
-Nothing to configure in this plugin. Metrics flow wherever your backend's
-OpenTelemetry SDK is already pointed, so follow the Backstage guide on
-[configuring an OpenTelemetry exporter][otel-setup] if you have not already.
+Nothing to configure in this plugin. Instruments are taken from the global
+OpenTelemetry meter, so metrics flow wherever your backend's OpenTelemetry SDK is
+already pointed. Follow the Backstage guide on
+[setting up OpenTelemetry][otel-setup] if you have not already.
 
-If your installation does not provide a `MetricsService`, the processor runs
-exactly as before and simply emits nothing.
+If no `MeterProvider` is registered, the OpenTelemetry API returns no-op
+instruments. An installation that never set up OpenTelemetry is therefore
+unaffected and needs no configuration.
+
+> Backstage also has an alpha `MetricsService`, which would be the more idiomatic
+> choice. It is not used here because `metricsServiceRef` has no default factory
+> and no released version of `@backstage/backend-defaults` implements
+> `alpha.core.metrics`, so depending on it would fail backend startup. Switching
+> over is a one-file change once an implementation ships.
 
 ## Instruments
 
-| Metric                                     | Type      | Attributes          | Description                                                          |
-| ------------------------------------------ | --------- | ------------------- | -------------------------------------------------------------------- |
-| `grafana_servicemodel.entities.processed`  | Counter   | `kind`              | Entities that matched the filter and were considered for a sync.     |
-| `grafana_servicemodel.entities.synced`     | Counter   | `kind`, `operation` | Entities written, or confirmed already current, in the ServiceModel. |
-| `grafana_servicemodel.entities.skipped`    | Counter   | `kind`, `reason`    | Entities deliberately not written.                                   |
-| `grafana_servicemodel.entities.failed`     | Counter   | `kind`, `code`      | Entities that could not be written.                                  |
-| `grafana_servicemodel.sync.duration`       | Histogram | `kind`, `outcome`   | Seconds to reconcile one entity.                                     |
-| `grafana_servicemodel.api.requests`        | Counter   | `operation`, `code` | ServiceModel API requests by response status.                        |
-| `grafana_servicemodel.connection.attempts` | Counter   | `outcome`           | Attempts to connect to Grafana Cloud.                                |
-| `grafana_servicemodel.connection.state`    | Gauge     | –                   | `1` when Grafana Cloud is reachable, `0` when it is not.             |
+| Metric                                     | Type             | Attributes          | Description                                                          |
+| ------------------------------------------ | ---------------- | ------------------- | -------------------------------------------------------------------- |
+| `grafana_servicemodel.entities.processed`  | Counter          | `kind`              | Entities that matched the filter and were considered for a sync.     |
+| `grafana_servicemodel.entities.synced`     | Counter          | `kind`, `operation` | Entities written, or confirmed already current, in the ServiceModel. |
+| `grafana_servicemodel.entities.skipped`    | Counter          | `kind`, `reason`    | Entities deliberately not written.                                   |
+| `grafana_servicemodel.entities.failed`     | Counter          | `kind`, `code`      | Entities that could not be written.                                  |
+| `grafana_servicemodel.sync.duration`       | Histogram        | `kind`, `outcome`   | Seconds to reconcile one entity.                                     |
+| `grafana_servicemodel.api.requests`        | Counter          | `operation`, `code` | ServiceModel API requests by response status.                        |
+| `grafana_servicemodel.connection.attempts` | Counter          | `outcome`           | Attempts to connect to Grafana Cloud.                                |
+| `grafana_servicemodel.connection.state`    | Observable gauge | –                   | `1` when Grafana Cloud is reachable, `0` when it is not.             |
 
 ### Attribute values
 
@@ -37,8 +44,11 @@ exactly as before and simply emits nothing.
   - `disconnected` — Grafana was unreachable, so the entity was left for a later cycle
 - `operation` on `api.requests` is `get`, `create`, `update`, or `discover`
   (`discover` is the API version lookup done when connecting).
-- `code` is the HTTP status from the ServiceModel API, or `unknown` for a
-  failure that never produced a response, such as a connection reset.
+- `code` is the HTTP status when the ServiceModel API returned a response, and
+  otherwise the transport error code — `ECONNRESET`, `ETIMEDOUT`,
+  `CERT_HAS_EXPIRED` and so on. It is `unknown` when the failure carried neither.
+  So a query filtering on `code="429"` sees only throttling, while connection
+  problems appear under their own codes rather than being lumped in.
 
 ### How the counters relate
 
@@ -52,6 +62,15 @@ processed = synced + failed + skipped{reason="unchanged"}
 An entity is counted once per catalog cycle, so all of these are rates over
 cycles rather than absolute inventory counts. To see how many services Grafana
 currently knows about, query the ServiceModel rather than these metrics.
+
+The relation holds _eventually_, not at every scrape. `postProcessEntity` returns
+without waiting for the ServiceModel write, so at any instant a few entities are
+counted in `processed` while their write is still in flight.
+
+Creating an entity issues **two** `get` requests — one from the existence check
+and one inside the create path — so `api.requests{operation="get"}` runs at
+roughly twice the create rate. Both requests are real, so the counter is accurate,
+but it is worth knowing before reading the ratio as a bug.
 
 ## Example queries
 
@@ -102,9 +121,15 @@ Metric names are shown here as declared. Exporters rewrite them to suit their
 own conventions, so a Prometheus scrape will show `_total` suffixes on counters
 and `.` replaced by `_`, as in the queries above.
 
-Attribute cardinality is bounded. `kind` comes from the small set of Backstage
-kinds you allow, and `code` from HTTP statuses, so entity names never become
-labels.
+`connection.state` is observable: it is sampled on every collection rather than
+written when a connection attempt happens. That matters because attempts stop once
+the connection is healthy, and are backed off up to an hour apart once it is not —
+a synchronous gauge would go stale or absent exactly when an outage alert needs to
+fire.
 
-[metrics-service]: https://backstage.io/docs/backend-system/core-services/metrics
+Attribute cardinality is bounded. `kind` comes from the small set of Backstage
+kinds you allow, and `code` from status and transport error codes, so entity names
+never become labels.
+
+[otel-api]: https://opentelemetry.io/docs/languages/js/instrumentation/#metrics
 [otel-setup]: https://backstage.io/docs/tutorials/setup-opentelemetry

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,8 @@ unaffected and needs no configuration.
 - `reason` on `entities.skipped` is:
   - `filtered` — the kind or type is not in `grafanaCloudCatalogInfo.allow`
   - `unchanged` — identical to the processor's cached copy, so no API call
-  - `disconnected` — Grafana was unreachable, so the entity was left for a later cycle
+  - `disconnected` — Grafana was not available when the entity arrived, so it was
+    left for a later cycle
 - `operation` on `api.requests` is `get`, `create`, `update`, or `discover`
   (`discover` is the API version lookup done when connecting).
 - `code` is the HTTP status when the ServiceModel API returned a response, and
@@ -49,6 +50,8 @@ unaffected and needs no configuration.
   `CERT_HAS_EXPIRED` and so on. It is `unknown` when the failure carried neither.
   So a query filtering on `code="429"` sees only throttling, while connection
   problems appear under their own codes rather than being lumped in.
+  A `409` is counted as a failure because the write did not land, even though it
+  is benign — the entity is not cached, so the next cycle retries it.
 
 ### How the counters relate
 
@@ -80,11 +83,13 @@ Is the connection up?
 grafana_servicemodel_connection_state
 ```
 
-Sync throughput and error rate over the last day:
+Sync throughput and error rate over the last day. A `409` means another writer
+updated the object first; the entity is retried on the next cycle, so it is worth
+excluding from an error-rate alert:
 
 ```promql
 sum(rate(grafana_servicemodel_entities_synced_total[1d]))
-sum(rate(grafana_servicemodel_entities_failed_total[1d]))
+sum(rate(grafana_servicemodel_entities_failed_total{code!="409"}[1d]))
 ```
 
 Alert when the connection has been down for 15 minutes:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,110 @@
+# Metrics
+
+The processor emits metrics through Backstage's [`MetricsService`][metrics-service],
+which is a facade over the OpenTelemetry meter API. The goal is that an operator
+can answer "did the last sync succeed?" from a dashboard, instead of grepping
+logs.
+
+## Setup
+
+Nothing to configure in this plugin. Metrics flow wherever your backend's
+OpenTelemetry SDK is already pointed, so follow the Backstage guide on
+[configuring an OpenTelemetry exporter][otel-setup] if you have not already.
+
+If your installation does not provide a `MetricsService`, the processor runs
+exactly as before and simply emits nothing.
+
+## Instruments
+
+| Metric                                     | Type      | Attributes          | Description                                                          |
+| ------------------------------------------ | --------- | ------------------- | -------------------------------------------------------------------- |
+| `grafana_servicemodel.entities.processed`  | Counter   | `kind`              | Entities that matched the filter and were considered for a sync.     |
+| `grafana_servicemodel.entities.synced`     | Counter   | `kind`, `operation` | Entities written, or confirmed already current, in the ServiceModel. |
+| `grafana_servicemodel.entities.skipped`    | Counter   | `kind`, `reason`    | Entities deliberately not written.                                   |
+| `grafana_servicemodel.entities.failed`     | Counter   | `kind`, `code`      | Entities that could not be written.                                  |
+| `grafana_servicemodel.sync.duration`       | Histogram | `kind`, `outcome`   | Seconds to reconcile one entity.                                     |
+| `grafana_servicemodel.api.requests`        | Counter   | `operation`, `code` | ServiceModel API requests by response status.                        |
+| `grafana_servicemodel.connection.attempts` | Counter   | `outcome`           | Attempts to connect to Grafana Cloud.                                |
+| `grafana_servicemodel.connection.state`    | Gauge     | –                   | `1` when Grafana Cloud is reachable, `0` when it is not.             |
+
+### Attribute values
+
+- `operation` on `entities.synced` is `create`, `update`, or `noop`. A `noop`
+  means the entity was already identical in Grafana, so no write was needed.
+- `reason` on `entities.skipped` is:
+  - `filtered` — the kind or type is not in `grafanaCloudCatalogInfo.allow`
+  - `unchanged` — identical to the processor's cached copy, so no API call
+  - `disconnected` — Grafana was unreachable, so the entity was left for a later cycle
+- `operation` on `api.requests` is `get`, `create`, `update`, or `discover`
+  (`discover` is the API version lookup done when connecting).
+- `code` is the HTTP status from the ServiceModel API, or `unknown` for a
+  failure that never produced a response, such as a connection reset.
+
+### How the counters relate
+
+`entities.processed` counts only entities that got as far as a sync decision, so
+`filtered` and `disconnected` skips are not included in it:
+
+```
+processed = synced + failed + skipped{reason="unchanged"}
+```
+
+An entity is counted once per catalog cycle, so all of these are rates over
+cycles rather than absolute inventory counts. To see how many services Grafana
+currently knows about, query the ServiceModel rather than these metrics.
+
+## Example queries
+
+Is the connection up?
+
+```promql
+grafana_servicemodel_connection_state
+```
+
+Sync throughput and error rate over the last day:
+
+```promql
+sum(rate(grafana_servicemodel_entities_synced_total[1d]))
+sum(rate(grafana_servicemodel_entities_failed_total[1d]))
+```
+
+Alert when the connection has been down for 15 minutes:
+
+```promql
+max_over_time(grafana_servicemodel_connection_state[15m]) == 0
+```
+
+Alert when nothing has synced in two hours, which catches a silent stall such as
+an expired token:
+
+```promql
+sum(increase(grafana_servicemodel_entities_synced_total[2h])) == 0
+```
+
+Are we being throttled?
+
+```promql
+sum by (operation) (rate(grafana_servicemodel_api_requests_total{code="429"}[5m]))
+```
+
+95th percentile sync latency:
+
+```promql
+histogram_quantile(
+  0.95,
+  sum by (le) (rate(grafana_servicemodel_sync_duration_bucket[5m]))
+)
+```
+
+## Notes
+
+Metric names are shown here as declared. Exporters rewrite them to suit their
+own conventions, so a Prometheus scrape will show `_total` suffixes on counters
+and `.` replaced by `_`, as in the queries above.
+
+Attribute cardinality is bounded. `kind` comes from the small set of Backstage
+kinds you allow, and `code` from HTTP statuses, so entity names never become
+labels.
+
+[metrics-service]: https://backstage.io/docs/backend-system/core-services/metrics
+[otel-setup]: https://backstage.io/docs/tutorials/setup-opentelemetry

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "install-hooks": "./scripts/install-hooks.sh"
   },
   "dependencies": {
-    "@backstage/backend-plugin-api": "^1.8.0",
+    "@backstage/backend-plugin-api": "^1.6.1",
     "@backstage/backend-test-utils": "^1.0.2",
     "@backstage/catalog-model": "^1.7.6",
     "@backstage/config": "^1.3.6",
@@ -49,6 +49,7 @@
     "@backstage/plugin-catalog-common": "^1.1.7",
     "@backstage/plugin-catalog-node": "^1.20.1",
     "@kubernetes/client-node": "^1.1.2",
+    "@opentelemetry/api": "^1.9.0",
     "@spotify/prettier-config": "^15.0.0",
     "@types/lodash": "^4.14.202",
     "jsonpath-plus": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "install-hooks": "./scripts/install-hooks.sh"
   },
   "dependencies": {
-    "@backstage/backend-plugin-api": "^1.6.1",
+    "@backstage/backend-plugin-api": "^1.8.0",
     "@backstage/backend-test-utils": "^1.0.2",
     "@backstage/catalog-model": "^1.7.6",
     "@backstage/config": "^1.3.6",

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,178 @@
+import type {
+  MetricsService,
+  MetricsServiceCounter,
+  MetricsServiceGauge,
+  MetricsServiceHistogram,
+} from '@backstage/backend-plugin-api/alpha';
+
+/**
+ * Why an entity was not sent to the ServiceModel API.
+ *
+ * - `filtered`: the entity kind/type is not in `grafanaCloudCatalogInfo.allow`
+ * - `unchanged`: the entity is byte-identical to the cached copy
+ * - `disconnected`: Grafana was unreachable, so the entity was left for a later cycle
+ */
+export type SkipReason = 'filtered' | 'unchanged' | 'disconnected';
+
+/** Which ServiceModel write was performed for an entity. */
+export type SyncOperation = 'create' | 'update' | 'noop';
+
+/** Which ServiceModel API call was made. */
+export type ApiOperation = 'get' | 'create' | 'update' | 'discover';
+
+/** How a single entity's sync attempt ended. */
+export type SyncOutcome = 'success' | 'failure';
+
+/**
+ * Prefix for every instrument this plugin creates.
+ *
+ * The MetricsService already scopes instruments per plugin, so this only needs
+ * to distinguish these metrics from other catalog modules.
+ */
+const PREFIX = 'grafana_servicemodel';
+
+/**
+ * Bucket boundaries for per-entity sync latency, in seconds. Skewed towards the
+ * sub-second range because a healthy sync is a couple of API round trips, with
+ * headroom up to the 30s request timeout.
+ */
+const DURATION_BUCKETS_SECONDS = [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60];
+
+/**
+ * Records what the GrafanaServiceModelProcessor is doing, so an operator can
+ * answer "did the last sync succeed?" from metrics alone rather than by reading
+ * logs.
+ *
+ * Every method is a no-op when no MetricsService is supplied. That keeps the
+ * processor's own code free of conditionals, keeps `fromConfig` usable without
+ * a MetricsService, and means an installation that has not wired up the alpha
+ * MetricsService still runs normally, just without metrics.
+ */
+export class GrafanaServiceModelMetrics {
+  private readonly entitiesProcessed?: MetricsServiceCounter;
+  private readonly entitiesSynced?: MetricsServiceCounter;
+  private readonly entitiesSkipped?: MetricsServiceCounter;
+  private readonly entitiesFailed?: MetricsServiceCounter;
+  private readonly syncDuration?: MetricsServiceHistogram;
+  private readonly apiRequests?: MetricsServiceCounter;
+  private readonly connectionAttempts?: MetricsServiceCounter;
+  private readonly connectionState?: MetricsServiceGauge;
+
+  constructor(metrics?: MetricsService) {
+    if (!metrics) {
+      return;
+    }
+
+    this.entitiesProcessed = metrics.createCounter(
+      `${PREFIX}.entities.processed`,
+      {
+        description:
+          'Entities the processor considered for the Grafana ServiceModel.',
+        unit: '{entity}',
+      },
+    );
+
+    this.entitiesSynced = metrics.createCounter(`${PREFIX}.entities.synced`, {
+      description: 'Entities successfully written to the Grafana ServiceModel.',
+      unit: '{entity}',
+    });
+
+    this.entitiesSkipped = metrics.createCounter(`${PREFIX}.entities.skipped`, {
+      description:
+        'Entities not written to the Grafana ServiceModel, by reason.',
+      unit: '{entity}',
+    });
+
+    this.entitiesFailed = metrics.createCounter(`${PREFIX}.entities.failed`, {
+      description:
+        'Entities that could not be written to the Grafana ServiceModel.',
+      unit: '{entity}',
+    });
+
+    this.syncDuration = metrics.createHistogram(`${PREFIX}.sync.duration`, {
+      description:
+        'Time to reconcile one entity against the Grafana ServiceModel.',
+      unit: 's',
+      advice: { explicitBucketBoundaries: DURATION_BUCKETS_SECONDS },
+    });
+
+    this.apiRequests = metrics.createCounter(`${PREFIX}.api.requests`, {
+      description:
+        'ServiceModel API requests, by operation and response status code.',
+      unit: '{request}',
+    });
+
+    this.connectionAttempts = metrics.createCounter(
+      `${PREFIX}.connection.attempts`,
+      {
+        description: 'Attempts to establish a connection to Grafana Cloud.',
+        unit: '{attempt}',
+      },
+    );
+
+    this.connectionState = metrics.createGauge(`${PREFIX}.connection.state`, {
+      description:
+        'Whether Grafana Cloud is currently reachable: 1 available, 0 unavailable.',
+      unit: '{state}',
+    });
+  }
+
+  /** An entity reached the processor and matched the configured filter. */
+  recordProcessed(kind: string): void {
+    this.entitiesProcessed?.add(1, { kind });
+  }
+
+  /** An entity was deliberately not written. */
+  recordSkipped(kind: string, reason: SkipReason): void {
+    this.entitiesSkipped?.add(1, { kind, reason });
+  }
+
+  /** An entity was written to the ServiceModel, or confirmed already current. */
+  recordSynced(kind: string, operation: SyncOperation): void {
+    this.entitiesSynced?.add(1, { kind, operation });
+  }
+
+  /**
+   * An entity could not be written.
+   *
+   * @param code - The HTTP status from the ServiceModel API, if the failure came
+   *   from a response. Reported as `unknown` otherwise, so that transport-level
+   *   failures are still counted.
+   */
+  recordFailed(kind: string, code?: number | string): void {
+    this.entitiesFailed?.add(1, { kind, code: String(code ?? 'unknown') });
+  }
+
+  /** How long one entity took to reconcile, in seconds. */
+  recordSyncDuration(
+    kind: string,
+    outcome: SyncOutcome,
+    durationMs: number,
+  ): void {
+    this.syncDuration?.record(durationMs / 1000, { kind, outcome });
+  }
+
+  /** A single ServiceModel API request completed, successfully or not. */
+  recordApiRequest(operation: ApiOperation, code?: number | string): void {
+    this.apiRequests?.add(1, {
+      operation,
+      code: String(code ?? 'unknown'),
+    });
+  }
+
+  /**
+   * A connection attempt finished. Also republishes the connection gauge, so the
+   * gauge and the attempt counter can never disagree.
+   */
+  recordConnectionAttempt(connected: boolean): void {
+    this.connectionAttempts?.add(1, {
+      outcome: connected ? 'success' : 'failure',
+    });
+    this.recordConnectionState(connected);
+  }
+
+  /** Publishes whether Grafana is currently reachable. */
+  recordConnectionState(connected: boolean): void {
+    this.connectionState?.record(connected ? 1 : 0);
+  }
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,9 +1,10 @@
+import { metrics as otelMetrics, ValueType } from '@opentelemetry/api';
 import type {
-  MetricsService,
-  MetricsServiceCounter,
-  MetricsServiceGauge,
-  MetricsServiceHistogram,
-} from '@backstage/backend-plugin-api/alpha';
+  Counter,
+  Histogram,
+  Meter,
+  ObservableGauge,
+} from '@opentelemetry/api';
 
 /**
  * Why an entity was not sent to the ServiceModel API.
@@ -24,10 +25,20 @@ export type ApiOperation = 'get' | 'create' | 'update' | 'discover';
 export type SyncOutcome = 'success' | 'failure';
 
 /**
- * Prefix for every instrument this plugin creates.
+ * Reports whether Grafana is currently reachable, or `undefined` when the
+ * processor is disabled and the question does not apply.
  *
- * The MetricsService already scopes instruments per plugin, so this only needs
- * to distinguish these metrics from other catalog modules.
+ * This is a function rather than a value because the connection gauge is
+ * observable: it is sampled at collection time, not when a connection attempt
+ * happens.
+ */
+export type ConnectionStateProvider = () => boolean | undefined;
+
+const METER_NAME = '@grafana/catalog-backend-module-grafana-servicemodel';
+
+/**
+ * Prefix for every instrument this plugin creates, to distinguish these metrics
+ * from other catalog modules sharing the same exporter.
  */
 const PREFIX = 'grafana_servicemodel';
 
@@ -43,104 +54,149 @@ const DURATION_BUCKETS_SECONDS = [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60];
  * answer "did the last sync succeed?" from metrics alone rather than by reading
  * logs.
  *
- * Every method is a no-op when no MetricsService is supplied. That keeps the
- * processor's own code free of conditionals, keeps `fromConfig` usable without
- * a MetricsService, and means an installation that has not wired up the alpha
- * MetricsService still runs normally, just without metrics.
+ * Instruments come from the global OpenTelemetry meter. When the host has not
+ * registered a MeterProvider the API hands back no-op instruments, so an
+ * installation that never set up OpenTelemetry is unaffected and needs no
+ * configuration.
+ *
+ * Every call here is also wrapped so that it cannot throw. Recording a metric
+ * happens inside promise executors that must reach `resolve()`, so an exception
+ * escaping this class would leave an entity's processing permanently unsettled.
+ * Observability must never be able to break catalog processing.
  */
 export class GrafanaServiceModelMetrics {
-  private readonly entitiesProcessed?: MetricsServiceCounter;
-  private readonly entitiesSynced?: MetricsServiceCounter;
-  private readonly entitiesSkipped?: MetricsServiceCounter;
-  private readonly entitiesFailed?: MetricsServiceCounter;
-  private readonly syncDuration?: MetricsServiceHistogram;
-  private readonly apiRequests?: MetricsServiceCounter;
-  private readonly connectionAttempts?: MetricsServiceCounter;
-  private readonly connectionState?: MetricsServiceGauge;
+  private readonly entitiesProcessed?: Counter;
+  private readonly entitiesSynced?: Counter;
+  private readonly entitiesSkipped?: Counter;
+  private readonly entitiesFailed?: Counter;
+  private readonly syncDuration?: Histogram;
+  private readonly apiRequests?: Counter;
+  private readonly connectionAttempts?: Counter;
+  private readonly connectionState?: ObservableGauge;
 
-  constructor(metrics?: MetricsService) {
-    if (!metrics) {
-      return;
-    }
-
-    this.entitiesProcessed = metrics.createCounter(
-      `${PREFIX}.entities.processed`,
-      {
+  constructor(
+    isConnected: ConnectionStateProvider,
+    meter: Meter = otelMetrics.getMeter(METER_NAME),
+  ) {
+    // Each instrument is created independently so that one unsupported option
+    // cannot cost us the rest of them.
+    this.entitiesProcessed = create(() =>
+      meter.createCounter(`${PREFIX}.entities.processed`, {
         description:
           'Entities the processor considered for the Grafana ServiceModel.',
         unit: '{entity}',
-      },
+        valueType: ValueType.INT,
+      }),
     );
 
-    this.entitiesSynced = metrics.createCounter(`${PREFIX}.entities.synced`, {
-      description: 'Entities successfully written to the Grafana ServiceModel.',
-      unit: '{entity}',
-    });
+    this.entitiesSynced = create(() =>
+      meter.createCounter(`${PREFIX}.entities.synced`, {
+        description:
+          'Entities successfully written to the Grafana ServiceModel.',
+        unit: '{entity}',
+        valueType: ValueType.INT,
+      }),
+    );
 
-    this.entitiesSkipped = metrics.createCounter(`${PREFIX}.entities.skipped`, {
-      description:
-        'Entities not written to the Grafana ServiceModel, by reason.',
-      unit: '{entity}',
-    });
+    this.entitiesSkipped = create(() =>
+      meter.createCounter(`${PREFIX}.entities.skipped`, {
+        description:
+          'Entities not written to the Grafana ServiceModel, by reason.',
+        unit: '{entity}',
+        valueType: ValueType.INT,
+      }),
+    );
 
-    this.entitiesFailed = metrics.createCounter(`${PREFIX}.entities.failed`, {
-      description:
-        'Entities that could not be written to the Grafana ServiceModel.',
-      unit: '{entity}',
-    });
+    this.entitiesFailed = create(() =>
+      meter.createCounter(`${PREFIX}.entities.failed`, {
+        description:
+          'Entities that could not be written to the Grafana ServiceModel.',
+        unit: '{entity}',
+        valueType: ValueType.INT,
+      }),
+    );
 
-    this.syncDuration = metrics.createHistogram(`${PREFIX}.sync.duration`, {
-      description:
-        'Time to reconcile one entity against the Grafana ServiceModel.',
-      unit: 's',
-      advice: { explicitBucketBoundaries: DURATION_BUCKETS_SECONDS },
-    });
+    this.syncDuration = create(() =>
+      meter.createHistogram(`${PREFIX}.sync.duration`, {
+        description:
+          'Time to reconcile one entity against the Grafana ServiceModel.',
+        unit: 's',
+        valueType: ValueType.DOUBLE,
+        advice: { explicitBucketBoundaries: DURATION_BUCKETS_SECONDS },
+      }),
+    );
 
-    this.apiRequests = metrics.createCounter(`${PREFIX}.api.requests`, {
-      description:
-        'ServiceModel API requests, by operation and response status code.',
-      unit: '{request}',
-    });
+    this.apiRequests = create(() =>
+      meter.createCounter(`${PREFIX}.api.requests`, {
+        description:
+          'ServiceModel API requests, by operation and response status code.',
+        unit: '{request}',
+        valueType: ValueType.INT,
+      }),
+    );
 
-    this.connectionAttempts = metrics.createCounter(
-      `${PREFIX}.connection.attempts`,
-      {
+    this.connectionAttempts = create(() =>
+      meter.createCounter(`${PREFIX}.connection.attempts`, {
         description: 'Attempts to establish a connection to Grafana Cloud.',
         unit: '{attempt}',
-      },
+        valueType: ValueType.INT,
+      }),
     );
 
-    this.connectionState = metrics.createGauge(`${PREFIX}.connection.state`, {
-      description:
-        'Whether Grafana Cloud is currently reachable: 1 available, 0 unavailable.',
-      unit: '{state}',
+    // Observable, so that every collection samples the current state. A
+    // synchronous gauge would only be written when a connection attempt happens,
+    // and attempts stop once the connection is healthy and are backed off up to
+    // an hour apart once it is not. That would leave the series stale or absent
+    // for long stretches, which is exactly when an outage alert needs to fire.
+    this.connectionState = create(() =>
+      meter.createObservableGauge(`${PREFIX}.connection.state`, {
+        description:
+          'Whether Grafana Cloud is currently reachable: 1 available, 0 unavailable.',
+        unit: '{state}',
+        valueType: ValueType.INT,
+      }),
+    );
+
+    this.connectionState?.addCallback(result => {
+      try {
+        const connected = isConnected();
+        // Undefined means the processor is disabled, so reporting 0 would look
+        // like an outage. Emit no data point at all instead.
+        if (connected !== undefined) {
+          result.observe(connected ? 1 : 0);
+        }
+      } catch {
+        // Never let collection fail because of us.
+      }
     });
   }
 
   /** An entity reached the processor and matched the configured filter. */
   recordProcessed(kind: string): void {
-    this.entitiesProcessed?.add(1, { kind });
+    swallow(() => this.entitiesProcessed?.add(1, { kind }));
   }
 
   /** An entity was deliberately not written. */
   recordSkipped(kind: string, reason: SkipReason): void {
-    this.entitiesSkipped?.add(1, { kind, reason });
+    swallow(() => this.entitiesSkipped?.add(1, { kind, reason }));
   }
 
   /** An entity was written to the ServiceModel, or confirmed already current. */
   recordSynced(kind: string, operation: SyncOperation): void {
-    this.entitiesSynced?.add(1, { kind, operation });
+    swallow(() => this.entitiesSynced?.add(1, { kind, operation }));
   }
 
   /**
    * An entity could not be written.
    *
-   * @param code - The HTTP status from the ServiceModel API, if the failure came
-   *   from a response. Reported as `unknown` otherwise, so that transport-level
-   *   failures are still counted.
+   * @param code - The status from the ServiceModel API when the failure produced
+   *   a response, otherwise the transport error code. Reported as `unknown` when
+   *   neither is available, so that no failure goes uncounted.
    */
   recordFailed(kind: string, code?: number | string): void {
-    this.entitiesFailed?.add(1, { kind, code: String(code ?? 'unknown') });
+    swallow(() =>
+      this.entitiesFailed?.add(1, { kind, code: String(code ?? 'unknown') }),
+    );
   }
 
   /** How long one entity took to reconcile, in seconds. */
@@ -149,30 +205,55 @@ export class GrafanaServiceModelMetrics {
     outcome: SyncOutcome,
     durationMs: number,
   ): void {
-    this.syncDuration?.record(durationMs / 1000, { kind, outcome });
+    swallow(() =>
+      this.syncDuration?.record(durationMs / 1000, { kind, outcome }),
+    );
   }
 
   /** A single ServiceModel API request completed, successfully or not. */
   recordApiRequest(operation: ApiOperation, code?: number | string): void {
-    this.apiRequests?.add(1, {
-      operation,
-      code: String(code ?? 'unknown'),
-    });
+    swallow(() =>
+      this.apiRequests?.add(1, {
+        operation,
+        code: String(code ?? 'unknown'),
+      }),
+    );
   }
 
-  /**
-   * A connection attempt finished. Also republishes the connection gauge, so the
-   * gauge and the attempt counter can never disagree.
-   */
+  /** A connection attempt finished. */
   recordConnectionAttempt(connected: boolean): void {
-    this.connectionAttempts?.add(1, {
-      outcome: connected ? 'success' : 'failure',
-    });
-    this.recordConnectionState(connected);
+    swallow(() =>
+      this.connectionAttempts?.add(1, {
+        outcome: connected ? 'success' : 'failure',
+      }),
+    );
   }
+}
 
-  /** Publishes whether Grafana is currently reachable. */
-  recordConnectionState(connected: boolean): void {
-    this.connectionState?.record(connected ? 1 : 0);
+/**
+ * Creates an instrument, yielding undefined rather than throwing if the meter
+ * rejects it. Every call site then treats the instrument as optional.
+ */
+function create<T>(factory: () => T): T | undefined {
+  try {
+    return factory();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Runs a recording call, discarding any error.
+ *
+ * The OpenTelemetry API is no-throw by contract, so this is defence in depth
+ * against a non-conforming MeterProvider. It is deliberately silent: these calls
+ * sit on the path to `resolve()` for an entity, and logging a metrics failure
+ * per entity would recreate the log flood this instrumentation exists to detect.
+ */
+function swallow(fn: () => void): void {
+  try {
+    fn();
+  } catch {
+    // Intentionally ignored.
   }
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,6 +2,7 @@ import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
+import { metricsServiceRef } from '@backstage/backend-plugin-api/alpha';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { GrafanaServiceModelProcessor } from './processor';
 
@@ -15,12 +16,14 @@ export const catalogModuleGrafanaServiceModelCustomProcessor =
           catalog: catalogProcessingExtensionPoint,
           logger: coreServices.logger,
           config: coreServices.rootConfig,
+          metrics: metricsServiceRef,
         },
-        async init({ config, catalog, logger }) {
+        async init({ config, catalog, logger, metrics }) {
           catalog.addProcessor(
             GrafanaServiceModelProcessor.fromConfig({
               logger: logger,
               config: config,
+              metrics: metrics,
             }),
           );
         },

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,7 +2,6 @@ import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
-import { metricsServiceRef } from '@backstage/backend-plugin-api/alpha';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { GrafanaServiceModelProcessor } from './processor';
 
@@ -16,14 +15,12 @@ export const catalogModuleGrafanaServiceModelCustomProcessor =
           catalog: catalogProcessingExtensionPoint,
           logger: coreServices.logger,
           config: coreServices.rootConfig,
-          metrics: metricsServiceRef,
         },
-        async init({ config, catalog, logger, metrics }) {
+        async init({ config, catalog, logger }) {
           catalog.addProcessor(
             GrafanaServiceModelProcessor.fromConfig({
               logger: logger,
               config: config,
-              metrics: metrics,
             }),
           );
         },

--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -367,3 +367,271 @@ describe('connection backoff', () => {
     );
   });
 });
+
+describe('metrics', () => {
+  const CONFIG = {
+    grafanaCloudCatalogInfo: {
+      enable: true,
+      stack_slug: 'dev',
+      grafana_endpoint: 'https://grafana-dev.com',
+      token: 'token',
+      allow: ['kind=Component,spec.type=service'],
+    },
+  };
+
+  const component: Entity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'test-entity' },
+    spec: { type: 'service' },
+  };
+
+  type Measurement = {
+    name: string;
+    value: number;
+    attributes: Record<string, unknown>;
+  };
+
+  /**
+   * A MetricsService that records every measurement, so tests can assert on the
+   * emitted series rather than on OpenTelemetry internals.
+   */
+  function fakeMetrics() {
+    const measurements: Measurement[] = [];
+    const instrument = (name: string) => ({
+      add: (value: number, attributes: Record<string, unknown> = {}) =>
+        measurements.push({ name, value, attributes }),
+      record: (value: number, attributes: Record<string, unknown> = {}) =>
+        measurements.push({ name, value, attributes }),
+    });
+
+    const service = {
+      createCounter: jest.fn((name: string) => instrument(name)),
+      createUpDownCounter: jest.fn((name: string) => instrument(name)),
+      createHistogram: jest.fn((name: string) => instrument(name)),
+      createGauge: jest.fn((name: string) => instrument(name)),
+      createObservableCounter: jest.fn(),
+      createObservableUpDownCounter: jest.fn(),
+      createObservableGauge: jest.fn(),
+    };
+
+    const of = (name: string) => measurements.filter(m => m.name === name);
+
+    return { service, measurements, of };
+  }
+
+  let logger: jest.Mocked<LoggerService>;
+  let connect: jest.SpyInstance<Promise<boolean>, []>;
+  let metrics: ReturnType<typeof fakeMetrics>;
+
+  beforeEach(() => {
+    logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn(),
+    } as unknown as jest.Mocked<LoggerService>;
+
+    metrics = fakeMetrics();
+
+    connect = jest
+      .spyOn(
+        GrafanaServiceModelProcessor.prototype,
+        'createAndTestGrafanaConnection',
+      )
+      .mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  async function newProcessor(withMetrics = true) {
+    const processor = GrafanaServiceModelProcessor.fromConfig({
+      logger,
+      config: new ConfigReader(CONFIG) as Config,
+      metrics: withMetrics ? (metrics.service as any) : undefined,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    return processor;
+  }
+
+  // postProcessEntity resolves without waiting for the ServiceModel write, so
+  // drain the microtask queue to let the sync's own handlers settle before
+  // asserting on what they recorded.
+  async function process(
+    processor: GrafanaServiceModelProcessor,
+    entity: Entity,
+    cached?: Entity,
+  ) {
+    const result = await processor.postProcessEntity!(
+      entity,
+      {} as LocationSpec,
+      jest.fn() as CatalogProcessorEmit,
+      {
+        get: jest.fn().mockResolvedValue(cached),
+        set: jest.fn().mockResolvedValue(undefined),
+      } as unknown as CatalogProcessorCache,
+    );
+    for (let i = 0; i < 4; i++) {
+      await Promise.resolve();
+    }
+    return result;
+  }
+
+  it('registers one instrument per series', async () => {
+    await newProcessor();
+
+    const created = [
+      ...metrics.service.createCounter.mock.calls,
+      ...metrics.service.createHistogram.mock.calls,
+      ...metrics.service.createGauge.mock.calls,
+    ].map(([name]) => name);
+
+    expect(created.sort()).toEqual([
+      'grafana_servicemodel.api.requests',
+      'grafana_servicemodel.connection.attempts',
+      'grafana_servicemodel.connection.state',
+      'grafana_servicemodel.entities.failed',
+      'grafana_servicemodel.entities.processed',
+      'grafana_servicemodel.entities.skipped',
+      'grafana_servicemodel.entities.synced',
+      'grafana_servicemodel.sync.duration',
+    ]);
+  });
+
+  it('reports the connection outcome and current state', async () => {
+    await newProcessor();
+
+    expect(metrics.of('grafana_servicemodel.connection.attempts')).toEqual([
+      {
+        name: expect.any(String),
+        value: 1,
+        attributes: { outcome: 'success' },
+      },
+    ]);
+    expect(metrics.of('grafana_servicemodel.connection.state')).toEqual([
+      { name: expect.any(String), value: 1, attributes: {} },
+    ]);
+  });
+
+  it('reports an unavailable connection as state 0', async () => {
+    connect.mockResolvedValue(false);
+    await newProcessor();
+
+    expect(metrics.of('grafana_servicemodel.connection.state')).toEqual([
+      { name: expect.any(String), value: 0, attributes: {} },
+    ]);
+    expect(
+      metrics.of('grafana_servicemodel.connection.attempts')[0].attributes,
+    ).toEqual({ outcome: 'failure' });
+  });
+
+  it('counts entities the filter excludes as skipped, not processed', async () => {
+    const processor = await newProcessor();
+
+    await process(processor, {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'a-website' },
+      spec: { type: 'website' },
+    });
+
+    expect(metrics.of('grafana_servicemodel.entities.skipped')).toEqual([
+      {
+        name: expect.any(String),
+        value: 1,
+        attributes: { kind: 'Component', reason: 'filtered' },
+      },
+    ]);
+    expect(metrics.of('grafana_servicemodel.entities.processed')).toHaveLength(
+      0,
+    );
+  });
+
+  it('counts an unchanged entity as processed and skipped', async () => {
+    const processor = await newProcessor();
+
+    await process(processor, component, component);
+
+    expect(metrics.of('grafana_servicemodel.entities.processed')).toEqual([
+      { name: expect.any(String), value: 1, attributes: { kind: 'Component' } },
+    ]);
+    expect(
+      metrics.of('grafana_servicemodel.entities.skipped')[0].attributes,
+    ).toEqual({ kind: 'Component', reason: 'unchanged' });
+    expect(metrics.of('grafana_servicemodel.sync.duration')).toHaveLength(0);
+  });
+
+  it('counts entities left behind by an outage as skipped', async () => {
+    connect.mockResolvedValue(false);
+    const processor = await newProcessor();
+
+    // Inside the backoff window, so this entity passes straight through
+    await process(processor, component);
+
+    expect(
+      metrics
+        .of('grafana_servicemodel.entities.skipped')
+        .map(m => m.attributes),
+    ).toEqual([{ kind: 'Component', reason: 'disconnected' }]);
+  });
+
+  it('times a successful sync', async () => {
+    const processor = await newProcessor();
+    jest.spyOn(processor, 'createOrUpdateModel').mockResolvedValue(true);
+
+    await process(processor, component);
+
+    const [duration] = metrics.of('grafana_servicemodel.sync.duration');
+    expect(duration.attributes).toEqual({
+      kind: 'Component',
+      outcome: 'success',
+    });
+    expect(duration.value).toBeGreaterThanOrEqual(0);
+    expect(metrics.of('grafana_servicemodel.entities.failed')).toHaveLength(0);
+  });
+
+  it('records the status code when a sync throws', async () => {
+    const processor = await newProcessor();
+    jest
+      .spyOn(processor, 'createOrUpdateModel')
+      .mockRejectedValue(Object.assign(new Error('boom'), { code: 500 }));
+
+    await process(processor, component);
+
+    expect(
+      metrics.of('grafana_servicemodel.sync.duration')[0].attributes,
+    ).toEqual({ kind: 'Component', outcome: 'failure' });
+    expect(metrics.of('grafana_servicemodel.entities.failed')).toEqual([
+      {
+        name: expect.any(String),
+        value: 1,
+        attributes: { kind: 'Component', code: '500' },
+      },
+    ]);
+  });
+
+  it('labels a failure with no status code as unknown', async () => {
+    const processor = await newProcessor();
+    jest
+      .spyOn(processor, 'createOrUpdateModel')
+      .mockRejectedValue(new Error('socket hang up'));
+
+    await process(processor, component);
+
+    expect(
+      metrics.of('grafana_servicemodel.entities.failed')[0].attributes,
+    ).toEqual({ kind: 'Component', code: 'unknown' });
+  });
+
+  it('runs normally when no metrics service is supplied', async () => {
+    const processor = await newProcessor(false);
+    jest.spyOn(processor, 'createOrUpdateModel').mockResolvedValue(true);
+
+    await expect(process(processor, component)).resolves.toBe(component);
+    expect(metrics.measurements).toHaveLength(0);
+  });
+});

--- a/src/processor.test.ts
+++ b/src/processor.test.ts
@@ -6,6 +6,7 @@ import {
   CatalogProcessorCache,
   CatalogProcessorEmit,
 } from '@backstage/plugin-catalog-node';
+import { metrics as otelMetrics } from '@opentelemetry/api';
 import {
   GrafanaServiceModelProcessor,
   entityToServiceModel,
@@ -387,42 +388,56 @@ describe('metrics', () => {
   };
 
   type Measurement = {
-    name: string;
     value: number;
     attributes: Record<string, unknown>;
   };
 
   /**
-   * A MetricsService that records every measurement, so tests can assert on the
-   * emitted series rather than on OpenTelemetry internals.
+   * A MeterProvider that records every measurement, registered globally so the
+   * processor resolves it through the same path it uses in production.
    */
-  function fakeMetrics() {
-    const measurements: Measurement[] = [];
-    const instrument = (name: string) => ({
-      add: (value: number, attributes: Record<string, unknown> = {}) =>
-        measurements.push({ name, value, attributes }),
-      record: (value: number, attributes: Record<string, unknown> = {}) =>
-        measurements.push({ name, value, attributes }),
-    });
+  function installMeter() {
+    const measurements = new Map<string, Measurement[]>();
+    const gaugeCallbacks: Array<() => void> = [];
 
-    const service = {
-      createCounter: jest.fn((name: string) => instrument(name)),
-      createUpDownCounter: jest.fn((name: string) => instrument(name)),
-      createHistogram: jest.fn((name: string) => instrument(name)),
-      createGauge: jest.fn((name: string) => instrument(name)),
-      createObservableCounter: jest.fn(),
-      createObservableUpDownCounter: jest.fn(),
-      createObservableGauge: jest.fn(),
+    const push =
+      (name: string) =>
+      (value: number, attributes = {}) => {
+        const list = measurements.get(name) ?? [];
+        list.push({ value, attributes });
+        measurements.set(name, list);
+      };
+
+    const meter = {
+      createCounter: (name: string) => ({ add: push(name) }),
+      createHistogram: (name: string) => ({ record: push(name) }),
+      createObservableGauge: (name: string) => ({
+        addCallback: (cb: (r: { observe: Function }) => void) =>
+          gaugeCallbacks.push(() =>
+            cb({
+              observe: (value: number, attributes = {}) =>
+                push(name)(value, attributes),
+            }),
+          ),
+        removeCallback: () => {},
+      }),
     };
 
-    const of = (name: string) => measurements.filter(m => m.name === name);
+    otelMetrics.disable();
+    otelMetrics.setGlobalMeterProvider({ getMeter: () => meter } as any);
 
-    return { service, measurements, of };
+    return {
+      of: (name: string) => measurements.get(name) ?? [],
+      names: () => [...measurements.keys()].sort(),
+      /** Runs the observable gauge callbacks, as a collection cycle would. */
+      collect: () => gaugeCallbacks.forEach(cb => cb()),
+      total: () => [...measurements.values()].flat().length,
+    };
   }
 
   let logger: jest.Mocked<LoggerService>;
   let connect: jest.SpyInstance<Promise<boolean>, []>;
-  let metrics: ReturnType<typeof fakeMetrics>;
+  let meter: ReturnType<typeof installMeter>;
 
   beforeEach(() => {
     logger = {
@@ -433,7 +448,7 @@ describe('metrics', () => {
       child: jest.fn(),
     } as unknown as jest.Mocked<LoggerService>;
 
-    metrics = fakeMetrics();
+    meter = installMeter();
 
     connect = jest
       .spyOn(
@@ -445,13 +460,13 @@ describe('metrics', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    otelMetrics.disable();
   });
 
-  async function newProcessor(withMetrics = true) {
+  async function newProcessor(config: object = CONFIG) {
     const processor = GrafanaServiceModelProcessor.fromConfig({
       logger,
-      config: new ConfigReader(CONFIG) as Config,
-      metrics: withMetrics ? (metrics.service as any) : undefined,
+      config: new ConfigReader(config) as Config,
     });
     await Promise.resolve();
     await Promise.resolve();
@@ -459,8 +474,8 @@ describe('metrics', () => {
   }
 
   // postProcessEntity resolves without waiting for the ServiceModel write, so
-  // drain the microtask queue to let the sync's own handlers settle before
-  // asserting on what they recorded.
+  // let the queue fully drain before asserting on what the write recorded.
+  // setImmediate runs after all pending microtasks regardless of chain depth.
   async function process(
     processor: GrafanaServiceModelProcessor,
     entity: Entity,
@@ -475,163 +490,381 @@ describe('metrics', () => {
         set: jest.fn().mockResolvedValue(undefined),
       } as unknown as CatalogProcessorCache,
     );
-    for (let i = 0; i < 4; i++) {
-      await Promise.resolve();
-    }
+    await new Promise(r => setImmediate(r));
     return result;
   }
 
+  /**
+   * Wires a fake ServiceModel client so the real create/update/noop paths run,
+   * rather than stubbing createOrUpdateModel and skipping them.
+   */
+  function installClient(
+    processor: GrafanaServiceModelProcessor,
+    handlers: {
+      get?: () => Promise<any>;
+      create?: () => Promise<any>;
+      update?: () => Promise<any>;
+    },
+  ) {
+    const notFound = () =>
+      Promise.reject(Object.assign(new Error(), { code: 404 }));
+    processor.serviceModelVersion = 'v1';
+    processor.k8sNamespace = 'stacks-1';
+    processor.client = {
+      getNamespacedCustomObject: jest.fn(handlers.get ?? notFound),
+      createNamespacedCustomObject: jest.fn(
+        handlers.create ?? (() => Promise.resolve({})),
+      ),
+      replaceNamespacedCustomObject: jest.fn(
+        handlers.update ?? (() => Promise.resolve({})),
+      ),
+    } as unknown as typeof processor.client;
+  }
+
+  /** The ServiceModel object the processor would consider already current. */
+  function storedModel(entity: Entity) {
+    return entityToServiceModel(entity, 'stacks-1', 'v1');
+  }
+
   it('registers one instrument per series', async () => {
-    await newProcessor();
+    const processor = await newProcessor();
+    installClient(processor, {});
+    await process(processor, component);
+    meter.collect();
 
-    const created = [
-      ...metrics.service.createCounter.mock.calls,
-      ...metrics.service.createHistogram.mock.calls,
-      ...metrics.service.createGauge.mock.calls,
-    ].map(([name]) => name);
-
-    expect(created.sort()).toEqual([
+    expect(meter.names()).toEqual([
       'grafana_servicemodel.api.requests',
       'grafana_servicemodel.connection.attempts',
       'grafana_servicemodel.connection.state',
-      'grafana_servicemodel.entities.failed',
       'grafana_servicemodel.entities.processed',
-      'grafana_servicemodel.entities.skipped',
       'grafana_servicemodel.entities.synced',
       'grafana_servicemodel.sync.duration',
     ]);
   });
 
-  it('reports the connection outcome and current state', async () => {
-    await newProcessor();
+  describe('connection state', () => {
+    it('is sampled at collection time, not only on connection attempts', async () => {
+      const processor = await newProcessor();
 
-    expect(metrics.of('grafana_servicemodel.connection.attempts')).toEqual([
-      {
-        name: expect.any(String),
-        value: 1,
-        attributes: { outcome: 'success' },
-      },
-    ]);
-    expect(metrics.of('grafana_servicemodel.connection.state')).toEqual([
-      { name: expect.any(String), value: 1, attributes: {} },
-    ]);
-  });
+      // Many collections between attempts, which is the normal steady state
+      meter.collect();
+      meter.collect();
+      expect(
+        meter.of('grafana_servicemodel.connection.state').map(m => m.value),
+      ).toEqual([1, 1]);
 
-  it('reports an unavailable connection as state 0', async () => {
-    connect.mockResolvedValue(false);
-    await newProcessor();
-
-    expect(metrics.of('grafana_servicemodel.connection.state')).toEqual([
-      { name: expect.any(String), value: 0, attributes: {} },
-    ]);
-    expect(
-      metrics.of('grafana_servicemodel.connection.attempts')[0].attributes,
-    ).toEqual({ outcome: 'failure' });
-  });
-
-  it('counts entities the filter excludes as skipped, not processed', async () => {
-    const processor = await newProcessor();
-
-    await process(processor, {
-      apiVersion: 'backstage.io/v1alpha1',
-      kind: 'Component',
-      metadata: { name: 'a-website' },
-      spec: { type: 'website' },
+      // A later outage is visible on the very next collection
+      processor.grafanaAvailable = false;
+      meter.collect();
+      expect(
+        meter.of('grafana_servicemodel.connection.state').map(m => m.value),
+      ).toEqual([1, 1, 0]);
     });
 
-    expect(metrics.of('grafana_servicemodel.entities.skipped')).toEqual([
-      {
-        name: expect.any(String),
-        value: 1,
-        attributes: { kind: 'Component', reason: 'filtered' },
-      },
-    ]);
-    expect(metrics.of('grafana_servicemodel.entities.processed')).toHaveLength(
-      0,
-    );
-  });
+    it('emits no data point while the processor is disabled', async () => {
+      await newProcessor({
+        grafanaCloudCatalogInfo: {
+          ...CONFIG.grafanaCloudCatalogInfo,
+          enable: false,
+        },
+      });
+      meter.collect();
 
-  it('counts an unchanged entity as processed and skipped', async () => {
-    const processor = await newProcessor();
-
-    await process(processor, component, component);
-
-    expect(metrics.of('grafana_servicemodel.entities.processed')).toEqual([
-      { name: expect.any(String), value: 1, attributes: { kind: 'Component' } },
-    ]);
-    expect(
-      metrics.of('grafana_servicemodel.entities.skipped')[0].attributes,
-    ).toEqual({ kind: 'Component', reason: 'unchanged' });
-    expect(metrics.of('grafana_servicemodel.sync.duration')).toHaveLength(0);
-  });
-
-  it('counts entities left behind by an outage as skipped', async () => {
-    connect.mockResolvedValue(false);
-    const processor = await newProcessor();
-
-    // Inside the backoff window, so this entity passes straight through
-    await process(processor, component);
-
-    expect(
-      metrics
-        .of('grafana_servicemodel.entities.skipped')
-        .map(m => m.attributes),
-    ).toEqual([{ kind: 'Component', reason: 'disconnected' }]);
-  });
-
-  it('times a successful sync', async () => {
-    const processor = await newProcessor();
-    jest.spyOn(processor, 'createOrUpdateModel').mockResolvedValue(true);
-
-    await process(processor, component);
-
-    const [duration] = metrics.of('grafana_servicemodel.sync.duration');
-    expect(duration.attributes).toEqual({
-      kind: 'Component',
-      outcome: 'success',
+      expect(meter.of('grafana_servicemodel.connection.state')).toHaveLength(0);
     });
-    expect(duration.value).toBeGreaterThanOrEqual(0);
-    expect(metrics.of('grafana_servicemodel.entities.failed')).toHaveLength(0);
+
+    it('reports the outcome of each connection attempt', async () => {
+      connect.mockResolvedValue(false);
+      await newProcessor();
+
+      expect(
+        meter.of('grafana_servicemodel.connection.attempts')[0].attributes,
+      ).toEqual({ outcome: 'failure' });
+    });
   });
 
-  it('records the status code when a sync throws', async () => {
+  describe('skip reasons', () => {
+    it('counts entities the filter excludes as filtered, not processed', async () => {
+      const processor = await newProcessor();
+
+      await process(processor, {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: { name: 'a-website' },
+        spec: { type: 'website' },
+      });
+
+      expect(
+        meter.of('grafana_servicemodel.entities.skipped')[0].attributes,
+      ).toEqual({ kind: 'Component', reason: 'filtered' });
+      expect(meter.of('grafana_servicemodel.entities.processed')).toHaveLength(
+        0,
+      );
+    });
+
+    it('counts a Location the same way the filter would', async () => {
+      const processor = await newProcessor();
+
+      await process(processor, {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Location',
+        metadata: { name: 'a-location' },
+      });
+
+      expect(
+        meter.of('grafana_servicemodel.entities.skipped')[0].attributes,
+      ).toEqual({ kind: 'Location', reason: 'filtered' });
+    });
+
+    it('counts an unchanged entity as processed and skipped, with no sync', async () => {
+      const processor = await newProcessor();
+
+      await process(processor, component, component);
+
+      expect(
+        meter.of('grafana_servicemodel.entities.processed')[0].attributes,
+      ).toEqual({ kind: 'Component' });
+      expect(
+        meter.of('grafana_servicemodel.entities.skipped')[0].attributes,
+      ).toEqual({ kind: 'Component', reason: 'unchanged' });
+      expect(meter.of('grafana_servicemodel.sync.duration')).toHaveLength(0);
+      expect(meter.of('grafana_servicemodel.api.requests')).toHaveLength(0);
+    });
+
+    it('counts entities left behind by an outage as disconnected', async () => {
+      connect.mockResolvedValue(false);
+      const processor = await newProcessor();
+
+      await process(processor, component);
+
+      expect(
+        meter.of('grafana_servicemodel.entities.skipped')[0].attributes,
+      ).toEqual({ kind: 'Component', reason: 'disconnected' });
+    });
+  });
+
+  describe('sync operations', () => {
+    it('labels a newly created entity as create', async () => {
+      const processor = await newProcessor();
+      installClient(processor, {}); // get -> 404, create -> ok
+      await process(processor, component);
+
+      expect(meter.of('grafana_servicemodel.entities.synced')).toEqual([
+        { value: 1, attributes: { kind: 'Component', operation: 'create' } },
+      ]);
+      expect(meter.of('grafana_servicemodel.entities.failed')).toHaveLength(0);
+    });
+
+    it('labels a changed entity as update', async () => {
+      const processor = await newProcessor();
+      installClient(processor, {
+        // Present, but with a spec that differs from the entity's
+        get: () => Promise.resolve({ spec: { type: 'stale' }, metadata: {} }),
+      });
+      await process(processor, component);
+
+      expect(meter.of('grafana_servicemodel.entities.synced')).toEqual([
+        { value: 1, attributes: { kind: 'Component', operation: 'update' } },
+      ]);
+    });
+
+    it('labels an already-current entity as noop and issues no write', async () => {
+      const processor = await newProcessor();
+      installClient(processor, {
+        get: () => Promise.resolve(storedModel(component)),
+      });
+      await process(processor, component);
+
+      expect(meter.of('grafana_servicemodel.entities.synced')).toEqual([
+        { value: 1, attributes: { kind: 'Component', operation: 'noop' } },
+      ]);
+      expect(
+        processor.client!.replaceNamespacedCustomObject,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('failures', () => {
+    it('counts a failed create as failed, not synced', async () => {
+      const processor = await newProcessor();
+      installClient(processor, {
+        create: () =>
+          Promise.reject(Object.assign(new Error('boom'), { code: 500 })),
+      });
+      await process(processor, component);
+
+      expect(meter.of('grafana_servicemodel.entities.failed')).toEqual([
+        { value: 1, attributes: { kind: 'Component', code: '500' } },
+      ]);
+      expect(meter.of('grafana_servicemodel.entities.synced')).toHaveLength(0);
+      // The write did not land, so the duration must not read as a success
+      expect(
+        meter.of('grafana_servicemodel.sync.duration')[0].attributes,
+      ).toEqual({ kind: 'Component', outcome: 'failure' });
+    });
+
+    it('does not cache an entity whose create failed', async () => {
+      const processor = await newProcessor();
+      installClient(processor, {
+        create: () =>
+          Promise.reject(Object.assign(new Error('boom'), { code: 500 })),
+      });
+
+      const cache = {
+        get: jest.fn().mockResolvedValue(undefined),
+        set: jest.fn().mockResolvedValue(undefined),
+      };
+      await processor.postProcessEntity!(
+        component,
+        {} as LocationSpec,
+        jest.fn() as CatalogProcessorEmit,
+        cache as unknown as CatalogProcessorCache,
+      );
+      await new Promise(r => setImmediate(r));
+
+      // Only the unconditional end-of-cycle write, never one crediting success
+      expect(cache.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('counts a failed update as failed, not synced', async () => {
+      const processor = await newProcessor();
+      installClient(processor, {
+        get: () => Promise.resolve({ spec: { type: 'stale' }, metadata: {} }),
+        update: () =>
+          Promise.reject(Object.assign(new Error('slow down'), { code: 429 })),
+      });
+      await process(processor, component);
+
+      expect(meter.of('grafana_servicemodel.entities.failed')).toEqual([
+        { value: 1, attributes: { kind: 'Component', code: '429' } },
+      ]);
+      expect(meter.of('grafana_servicemodel.entities.synced')).toHaveLength(0);
+      expect(
+        meter.of('grafana_servicemodel.sync.duration')[0].attributes,
+      ).toEqual({ kind: 'Component', outcome: 'failure' });
+    });
+
+    it('does not cache an entity whose update failed', async () => {
+      const processor = await newProcessor();
+      installClient(processor, {
+        get: () => Promise.resolve({ spec: { type: 'stale' }, metadata: {} }),
+        update: () =>
+          Promise.reject(Object.assign(new Error('slow down'), { code: 429 })),
+      });
+
+      const cache = {
+        get: jest.fn().mockResolvedValue(undefined),
+        set: jest.fn().mockResolvedValue(undefined),
+      };
+      await processor.postProcessEntity!(
+        component,
+        {} as LocationSpec,
+        jest.fn() as CatalogProcessorEmit,
+        cache as unknown as CatalogProcessorCache,
+      );
+      await new Promise(r => setImmediate(r));
+
+      expect(cache.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('records the status code when a sync throws', async () => {
+      const processor = await newProcessor();
+      jest
+        .spyOn(processor, 'createOrUpdateModel')
+        .mockRejectedValue(Object.assign(new Error('boom'), { code: 503 }));
+
+      await process(processor, component);
+
+      expect(
+        meter.of('grafana_servicemodel.entities.failed')[0].attributes,
+      ).toEqual({ kind: 'Component', code: '503' });
+    });
+
+    it('labels a transport failure with its error code', async () => {
+      const processor = await newProcessor();
+      jest
+        .spyOn(processor, 'createOrUpdateModel')
+        .mockRejectedValue(
+          Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }),
+        );
+
+      await process(processor, component);
+
+      expect(
+        meter.of('grafana_servicemodel.entities.failed')[0].attributes,
+      ).toEqual({ kind: 'Component', code: 'ECONNRESET' });
+    });
+
+    it('labels a failure carrying no code as unknown', async () => {
+      const processor = await newProcessor();
+      jest
+        .spyOn(processor, 'createOrUpdateModel')
+        .mockRejectedValue(new Error('opaque'));
+
+      await process(processor, component);
+
+      expect(
+        meter.of('grafana_servicemodel.entities.failed')[0].attributes,
+      ).toEqual({ kind: 'Component', code: 'unknown' });
+    });
+  });
+
+  describe('api requests', () => {
+    it('counts each request by operation and status', async () => {
+      const processor = await newProcessor();
+      installClient(processor, {}); // get -> 404, then create -> 200
+      await process(processor, component);
+
+      expect(meter.of('grafana_servicemodel.api.requests')).toEqual([
+        { value: 1, attributes: { operation: 'get', code: '404' } },
+        { value: 1, attributes: { operation: 'get', code: '404' } },
+        { value: 1, attributes: { operation: 'create', code: '200' } },
+      ]);
+    });
+
+    it('counts a throttled update with its status code', async () => {
+      const processor = await newProcessor();
+      installClient(processor, {
+        get: () => Promise.resolve({ spec: { type: 'stale' }, metadata: {} }),
+        update: () =>
+          Promise.reject(Object.assign(new Error('slow down'), { code: 429 })),
+      });
+      await process(processor, component);
+
+      expect(meter.of('grafana_servicemodel.api.requests')).toEqual([
+        { value: 1, attributes: { operation: 'get', code: '200' } },
+        { value: 1, attributes: { operation: 'update', code: '429' } },
+      ]);
+    });
+  });
+
+  describe('sync duration', () => {
+    it('is recorded in seconds', async () => {
+      const processor = await newProcessor();
+      installClient(processor, {});
+
+      // A 1.5s sync, so a milliseconds/seconds mix-up cannot pass
+      const now = jest
+        .spyOn(Date, 'now')
+        .mockReturnValueOnce(10_000)
+        .mockReturnValue(11_500);
+
+      await process(processor, component);
+      now.mockRestore();
+
+      expect(meter.of('grafana_servicemodel.sync.duration')).toEqual([
+        { value: 1.5, attributes: { kind: 'Component', outcome: 'success' } },
+      ]);
+    });
+  });
+
+  it('runs normally when no MeterProvider is registered', async () => {
+    otelMetrics.disable();
+
     const processor = await newProcessor();
-    jest
-      .spyOn(processor, 'createOrUpdateModel')
-      .mockRejectedValue(Object.assign(new Error('boom'), { code: 500 }));
-
-    await process(processor, component);
-
-    expect(
-      metrics.of('grafana_servicemodel.sync.duration')[0].attributes,
-    ).toEqual({ kind: 'Component', outcome: 'failure' });
-    expect(metrics.of('grafana_servicemodel.entities.failed')).toEqual([
-      {
-        name: expect.any(String),
-        value: 1,
-        attributes: { kind: 'Component', code: '500' },
-      },
-    ]);
-  });
-
-  it('labels a failure with no status code as unknown', async () => {
-    const processor = await newProcessor();
-    jest
-      .spyOn(processor, 'createOrUpdateModel')
-      .mockRejectedValue(new Error('socket hang up'));
-
-    await process(processor, component);
-
-    expect(
-      metrics.of('grafana_servicemodel.entities.failed')[0].attributes,
-    ).toEqual({ kind: 'Component', code: 'unknown' });
-  });
-
-  it('runs normally when no metrics service is supplied', async () => {
-    const processor = await newProcessor(false);
-    jest.spyOn(processor, 'createOrUpdateModel').mockResolvedValue(true);
+    installClient(processor, {});
 
     await expect(process(processor, component)).resolves.toBe(component);
-    expect(metrics.measurements).toHaveLength(0);
+    expect(meter.total()).toBe(0);
   });
 });

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -24,10 +24,12 @@ import {
 } from '@backstage/plugin-catalog-node';
 import { Config } from '@backstage/config';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import type { MetricsService } from '@backstage/backend-plugin-api/alpha';
 
 import { getGrafanaCloudK8sConfig } from './kube_config';
 
 import { anyOfMultipleFilters, entityMatch } from './entityFilter';
+import { GrafanaServiceModelMetrics } from './metrics';
 
 const API_GROUP = 'servicemodel.ext.grafana.com';
 
@@ -63,6 +65,7 @@ export interface KubernetesObjectWithSpec extends KubernetesObject {
 export class GrafanaServiceModelProcessor implements CatalogProcessor {
   private readonly logger: LoggerService;
   private readonly config: Config;
+  private readonly metrics: GrafanaServiceModelMetrics;
 
   // Weather the processor is enabled
   enable: boolean = false;
@@ -90,27 +93,37 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
    * fromComfig creates a new GrafanaServiceModelProcessor from the config
    * @param logger - The logger service
    * @param config - The config service
+   * @param metrics - The alpha metrics service. Optional: when omitted the
+   *   processor runs normally and simply does not emit metrics.
    * @returns - A new GrafanaServiceModelProcessor
    */
   public static fromConfig({
     logger,
     config,
+    metrics,
   }: {
     logger: LoggerService;
     config: Config;
+    metrics?: MetricsService;
   }) {
-    return new GrafanaServiceModelProcessor(logger, config);
+    return new GrafanaServiceModelProcessor(logger, config, metrics);
   }
 
   /**
    * Create a new GrafanaServiceModelProcessor
    * @param logger - The logger service
    * @param config - The config service
+   * @param metrics - The alpha metrics service, if available
    * @returns - A new GrafanaServiceModelProcessor
    */
-  private constructor(logger: LoggerService, config: Config) {
+  private constructor(
+    logger: LoggerService,
+    config: Config,
+    metrics?: MetricsService,
+  ) {
     this.logger = logger;
     this.config = config;
+    this.metrics = new GrafanaServiceModelMetrics(metrics);
     this.grafanaAvailable = false;
 
     // Gracefully disable if config block is absent (e.g. local development)
@@ -173,6 +186,8 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
    * @param connected - Whether the connection attempt succeeded
    */
   private recordConnectionResult(connected: boolean): void {
+    this.metrics.recordConnectionAttempt(connected);
+
     if (connected) {
       if (this.consecutiveFailures > 0) {
         this.logger.info('GrafanaServiceModelProcessor: Connection restored.');
@@ -243,6 +258,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         const apiApiClient = this.kc?.makeApiClient(k8s.ApisApi);
         try {
           const response = await apiApiClient.getAPIVersions();
+          this.metrics.recordApiRequest('discover', 200);
           this.logger.debug(
             `GrafanaServiceModelProcessor: API versions response: ${JSON.stringify(
               response,
@@ -285,6 +301,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
           resolve(true);
           return;
         } catch (error: any) {
+          this.metrics.recordApiRequest('discover', error?.code);
           this.logger.error(
             `GrafanaServiceModelProcessor: k8s not available. Error: ${
               error?.message || error?.toString() || 'Unknown error'
@@ -336,6 +353,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
           now.getTime() - this.lastConnectionAttempt.getTime() <
             this.connectionBackoffMs()
         ) {
+          this.metrics.recordSkipped(entity.kind, 'disconnected');
           resolve(entity);
           return;
         }
@@ -347,21 +365,28 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
           this.grafanaAvailable = result;
           this.recordConnectionResult(result);
           // Catch you next time
+          this.metrics.recordSkipped(entity.kind, 'disconnected');
           resolve(entity);
           return;
         });
       } else {
         // Skip if kind is a Location or API
         if (entity.kind === 'Location') {
+          // A fast path for what the filter below would reject anyway, so it is
+          // counted the same way.
+          this.metrics.recordSkipped(entity.kind, 'filtered');
           resolve(entity);
           return;
         }
 
         // Skip if the kind is not in the list of allowed kinds
         if (!entityMatch(entity, this.filter)) {
+          this.metrics.recordSkipped(entity.kind, 'filtered');
           resolve(entity);
           return;
         }
+
+        this.metrics.recordProcessed(entity.kind);
 
         this.logger.debug(
           `GrafanaServiceModelProcessor.postProcessEntity entity '${entity.kind}' with name '${entity.metadata.name}`,
@@ -380,8 +405,14 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
           }
 
           if (!cachedEntity || !_.isEqual(entity, cachedEntity)) {
+            const startedAt = Date.now();
             this.createOrUpdateModel(entity)
               .then(async result => {
+                this.metrics.recordSyncDuration(
+                  entity.kind,
+                  result ? 'success' : 'failure',
+                  Date.now() - startedAt,
+                );
                 if (result) {
                   // Update the cache if we were successful in storing the model
                   cache.set(CACHE_KEY, entity);
@@ -390,6 +421,12 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
                 }
               })
               .catch((err: any) => {
+                this.metrics.recordSyncDuration(
+                  entity.kind,
+                  'failure',
+                  Date.now() - startedAt,
+                );
+                this.metrics.recordFailed(entity.kind, err?.code);
                 this.logger.error(
                   `GrafanaServiceModelProcessor.postProcessEntity error: ${
                     err.message || 'Unknown error'
@@ -413,6 +450,8 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
                 // Eat the error, we don't want to stop the catalog from processing
                 // don't cache the entity, we will want to procees it again.
               });
+          } else {
+            this.metrics.recordSkipped(entity.kind, 'unchanged');
           }
           // The cache is ephemeral between invocations, so we need to add the entity to the cache
           // on every invocation.
@@ -464,8 +503,12 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
           model.metadata!.resourceVersion =
             storedModel.metadata?.resourceVersion;
           return this.updateModel(entity, model)
-            .then(() => true)
+            .then(() => {
+              this.metrics.recordSynced(entity.kind, 'update');
+              return true;
+            })
             .catch(err => {
+              this.metrics.recordFailed(entity.kind, err?.code);
               if (err.code !== 409) {
                 this.logger.error(
                   `GrafanaServiceModelProcessor.createOrUpdateModel error updating model`,
@@ -490,6 +533,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
             });
         }
 
+        this.metrics.recordSynced(entity.kind, 'noop');
         return true;
       })
       .catch(err => {
@@ -546,6 +590,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         name: entity.metadata.name,
       })
       .then((response: any) => {
+        this.metrics.recordApiRequest('get', 200);
         this.logger.debug(
           `GrafanaServiceModelProcessor.getModel response: ${JSON.stringify(
             response,
@@ -554,6 +599,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         return response as KubernetesObjectWithSpec;
       })
       .catch((err: any) => {
+        this.metrics.recordApiRequest('get', err?.code);
         throw err;
       });
   }
@@ -581,6 +627,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
       })
       .then((response: any) => {
         k8sObject = response as KubernetesObjectWithSpec;
+        this.metrics.recordApiRequest('update', 200);
         this.logger.debug(
           `GrafanaServiceModelProcessor.updateModel replaceNamespacedCustomObject() response: ${JSON.stringify(
             k8sObject,
@@ -588,6 +635,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         );
       })
       .catch((err: any) => {
+        this.metrics.recordApiRequest('update', err?.code);
         this.logger.error(
           `GrafanaServiceModelProcessor.updateModel error: ${JSON.stringify(
             err,
@@ -619,6 +667,9 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         })
         .then((response: any) => {
           k8sObject = response as KubernetesObjectWithSpec;
+          this.metrics.recordApiRequest('get', 200);
+          // The object already exists, so there is nothing to create.
+          this.metrics.recordSynced(entity.kind, 'noop');
           this.logger.debug(
             `GrafanaServiceModelProcessor.createModel getNamespacedCustomObject() response: ${JSON.stringify(
               k8sObject,
@@ -627,6 +678,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
         })
         // A 404 is expected if the object does not exist
         .catch((_err: any) => {
+          this.metrics.recordApiRequest('get', _err?.code);
           const k8sModel = entityToServiceModel(
             entity,
             this.k8sNamespace,
@@ -645,6 +697,8 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
             })
             .then((response: any) => {
               k8sObject = response as KubernetesObjectWithSpec;
+              this.metrics.recordApiRequest('create', 200);
+              this.metrics.recordSynced(entity.kind, 'create');
               this.logger.debug(
                 `GrafanaServiceModelProcessor.createModel response: ${JSON.stringify(
                   k8sObject,
@@ -652,6 +706,11 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
               );
             })
             .catch((e: any) => {
+              // This error is swallowed rather than rethrown, so the caller still
+              // resolves successfully. Counting the entity as failed here keeps
+              // the metrics honest about the write not having landed.
+              this.metrics.recordApiRequest('create', e?.code);
+              this.metrics.recordFailed(entity.kind, e?.code);
               this.logger.error(
                 `GrafanaServiceModelProcessor.createModel error: ${JSON.stringify(
                   e,

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -24,7 +24,6 @@ import {
 } from '@backstage/plugin-catalog-node';
 import { Config } from '@backstage/config';
 import { LoggerService } from '@backstage/backend-plugin-api';
-import type { MetricsService } from '@backstage/backend-plugin-api/alpha';
 
 import { getGrafanaCloudK8sConfig } from './kube_config';
 
@@ -93,37 +92,33 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
    * fromComfig creates a new GrafanaServiceModelProcessor from the config
    * @param logger - The logger service
    * @param config - The config service
-   * @param metrics - The alpha metrics service. Optional: when omitted the
-   *   processor runs normally and simply does not emit metrics.
    * @returns - A new GrafanaServiceModelProcessor
    */
   public static fromConfig({
     logger,
     config,
-    metrics,
   }: {
     logger: LoggerService;
     config: Config;
-    metrics?: MetricsService;
   }) {
-    return new GrafanaServiceModelProcessor(logger, config, metrics);
+    return new GrafanaServiceModelProcessor(logger, config);
   }
 
   /**
    * Create a new GrafanaServiceModelProcessor
    * @param logger - The logger service
    * @param config - The config service
-   * @param metrics - The alpha metrics service, if available
    * @returns - A new GrafanaServiceModelProcessor
    */
-  private constructor(
-    logger: LoggerService,
-    config: Config,
-    metrics?: MetricsService,
-  ) {
+  private constructor(logger: LoggerService, config: Config) {
     this.logger = logger;
     this.config = config;
-    this.metrics = new GrafanaServiceModelMetrics(metrics);
+    // Sampled at collection time, so it reflects live state rather than the
+    // state at the last connection attempt. Undefined while disabled, so a
+    // disabled processor does not look like an outage.
+    this.metrics = new GrafanaServiceModelMetrics(() =>
+      this.enable ? this.grafanaAvailable : undefined,
+    );
     this.grafanaAvailable = false;
 
     // Gracefully disable if config block is absent (e.g. local development)
@@ -483,7 +478,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
           this.logger.debug(
             `GrafanaServiceModelProcessor.createOrUpdateModel: No existing model found for ${entity.kind}/${entity.metadata.name}, creating new one`,
           );
-          return this.createModel(entity).then(() => true);
+          return this.createModel(entity);
         }
         // As Backstage is the system of record, we just override the model in Grafana.
         // In the future, we may need to do some reconciliation of state, such at alerts
@@ -542,7 +537,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
           this.logger.debug(
             `GrafanaServiceModelProcessor.createOrUpdateModel: Model not found for ${entity.kind}/${entity.metadata.name}, creating new one`,
           );
-          return this.createModel(entity).then(() => true);
+          return this.createModel(entity);
         }
 
         this.logger.error(
@@ -648,9 +643,14 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
   /**
    * createModel creates the model in the GrafanaServiceModel
    * @param entity - The entity to create in the GrafanaServiceModel
-   * @returns - A promise that resolves to the created model in the GrafanaServiceModel
+   * @returns - A promise that resolves to true if the object is present in the
+   *   ServiceModel afterwards, false if the create failed. The error is not
+   *   rethrown, so a failure here still cannot interrupt catalog processing, but
+   *   the caller needs to know it happened: reporting success would both
+   *   mislabel the metrics and cache the entity as written, which would stop it
+   *   being retried on later cycles.
    */
-  async createModel(entity: Entity) {
+  async createModel(entity: Entity): Promise<boolean> {
     if (!this.client) {
       throw new Error('Kubernetes client not initialized');
     }
@@ -675,6 +675,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
               k8sObject,
             )}`,
           );
+          return true;
         })
         // A 404 is expected if the object does not exist
         .catch((_err: any) => {
@@ -704,11 +705,9 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
                   k8sObject,
                 )}`,
               );
+              return true;
             })
             .catch((e: any) => {
-              // This error is swallowed rather than rethrown, so the caller still
-              // resolves successfully. Counting the entity as failed here keeps
-              // the metrics honest about the write not having landed.
               this.metrics.recordApiRequest('create', e?.code);
               this.metrics.recordFailed(entity.kind, e?.code);
               this.logger.error(
@@ -716,6 +715,7 @@ export class GrafanaServiceModelProcessor implements CatalogProcessor {
                   e,
                 )} ${JSON.stringify(e)}`,
               );
+              return false;
             });
         })
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1683,6 +1683,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-plugin-api@npm:^1.8.0, @backstage/backend-plugin-api@npm:^1.9.3":
+  version: 1.9.3
+  resolution: "@backstage/backend-plugin-api@npm:1.9.3"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.3.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-auth-node": "npm:^0.7.3"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/plugin-permission-node": "npm:^0.11.2"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/json-schema": "npm:^7.0.6"
+    "@types/luxon": "npm:^3.0.0"
+    knex: "npm:^3.0.0"
+    luxon: "npm:^3.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  checksum: 10c0/cf8547920e88bc94b812aae4b93a2d68dcf8e1cba0aa9065ca4530b795f6e89a9ec8e184a4e44ed342612ec2bb4fb25e195325a25b08edd1264b3e2de76208c2
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-test-utils@npm:^1.0.2":
   version: 1.10.3
   resolution: "@backstage/backend-test-utils@npm:1.10.3"
@@ -1735,6 +1756,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/catalog-client@npm:^1.16.1":
+  version: 1.16.1
+  resolution: "@backstage/catalog-client@npm:1.16.1"
+  dependencies:
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/filter-predicates": "npm:^0.1.4"
+    "@backstage/plugin-catalog-common": "npm:^1.1.10"
+    cross-fetch: "npm:^4.0.0"
+    lodash: "npm:^4.17.21"
+    uri-template: "npm:^2.0.0"
+  checksum: 10c0/4b00fbada78234dd7a17863cef6134193b6d0396888cbcbfcda397d7321c594826f4f092d6bd6ac725e32a91ac3baf44a53a3bab5645ac7ef7c7ee803388f64f
+  languageName: node
+  linkType: hard
+
 "@backstage/catalog-model@npm:^1.7.6":
   version: 1.7.6
   resolution: "@backstage/catalog-model@npm:1.7.6"
@@ -1747,6 +1783,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/catalog-model@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "@backstage/catalog-model@npm:1.9.0"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    ajv: "npm:^8.10.0"
+    ajv-errors: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    zod: "npm:^3.25.76"
+  checksum: 10c0/05ae984123b56d830861f23c428c11e2e62b273757fcef318afe26e361f09c2bc87976dfea602bf0933fafa82955bc31e6ac0f4e8ab7bcaa583ea4755da4239f
+  languageName: node
+  linkType: hard
+
 "@backstage/cli-common@npm:^0.1.16, @backstage/cli-common@npm:^0.1.17":
   version: 0.1.17
   resolution: "@backstage/cli-common@npm:0.1.17"
@@ -1756,6 +1806,16 @@ __metadata:
     global-agent: "npm:^3.0.0"
     undici: "npm:^7.2.3"
   checksum: 10c0/85dc7c7ecfbd1dc47f83b6a320a09c83773f9a6357b4186bbf53541f1f58db6dc576ed7de84c1285e38fdbe9c02851b63f48dd4474845f36fe3f33dc4ecb28e9
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-common@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@backstage/cli-common@npm:0.3.0"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.1"
+    cross-spawn: "npm:^7.0.3"
+  checksum: 10c0/c6ae3bf3697bf463e0043150c0e56e4075ff9fd516e786593845c02de47ee72c4dad64cc1cfd9f54685b11ba9ed075ffa11eb764cc65da58ca3367da18a5dca1
   languageName: node
   linkType: hard
 
@@ -1955,6 +2015,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/config@npm:^1.3.8":
+  version: 1.3.8
+  resolution: "@backstage/config@npm:1.3.8"
+  dependencies:
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    ms: "npm:^2.1.3"
+  checksum: 10c0/bd9e1fdd7ab8e56a9814a7f67502ed69f9abd0f014dae44d253a6a02c0c6bf844451d037afa991b200fc09d89e7195593bd5a9459357dafd8101dc826e664dec
+  languageName: node
+  linkType: hard
+
 "@backstage/errors@npm:^1.2.7":
   version: 1.2.7
   resolution: "@backstage/errors@npm:1.2.7"
@@ -1965,6 +2036,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/errors@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@backstage/errors@npm:1.3.1"
+  dependencies:
+    "@backstage/types": "npm:^1.2.2"
+    serialize-error: "npm:^8.0.1"
+  checksum: 10c0/b342551f5337f17bcc6d412868f6274509d657cc6037fbb5af96d42156c24c2419e72fd711136e42d05245bd4e5c5d8fe9cd54f89f260d9285a073c28cca0261
+  languageName: node
+  linkType: hard
+
 "@backstage/eslint-plugin@npm:^0.2.0":
   version: 0.2.0
   resolution: "@backstage/eslint-plugin@npm:0.2.0"
@@ -1972,6 +2053,19 @@ __metadata:
     "@manypkg/get-packages": "npm:^1.1.3"
     minimatch: "npm:^9.0.0"
   checksum: 10c0/7f57cd42629084b0363cf9adb37d33479fd540226a29705da623db9032890a6e67d1eb15b8076ea2fe3b502e36810ad819c93936406524e56e33801b561d6ff3
+  languageName: node
+  linkType: hard
+
+"@backstage/filter-predicates@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "@backstage/filter-predicates@npm:0.1.4"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-validation-error: "npm:^5.0.0"
+  checksum: 10c0/0e54760800797c45df47f58f0c1138cd2667939f0d1a4b83c63466fed82b293ffc144751bf98684b2e61edcc111c1cb34ebf607f19befd361e9b8f061f04d1cc
   languageName: node
   linkType: hard
 
@@ -2031,6 +2125,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-auth-node@npm:^0.7.3":
+  version: 0.7.3
+  resolution: "@backstage/plugin-auth-node@npm:0.7.3"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
+    "@backstage/catalog-client": "npm:^1.16.1"
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/passport": "npm:^1.0.3"
+    express: "npm:^4.22.0"
+    jose: "npm:^5.0.0"
+    lodash: "npm:^4.17.21"
+    passport: "npm:^0.7.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+    zod-validation-error: "npm:^5.0.0"
+  checksum: 10c0/faf274cc6d13193ef8aa6daa8dba33219ee8661029e603c6eb8e80f3ed7a35860a7b5603b2667c61b9c2df976a1ede836467ee3a94be08b4b31cb910fea10f90
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-catalog-backend@npm:^3.3.1":
   version: 3.3.1
   resolution: "@backstage/plugin-catalog-backend@npm:3.3.1"
@@ -2067,6 +2184,17 @@ __metadata:
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
   checksum: 10c0/1a0cb3ff464e34f0b48d2be83933e2f4950a16808ccb9159e701f16116a80235a2e9998aefc48a5df9ef11df43341a6b16761ba182c2407e7e8f457967f81b0c
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-common@npm:^1.1.10":
+  version: 1.1.10
+  resolution: "@backstage/plugin-catalog-common@npm:1.1.10"
+  dependencies:
+    "@backstage/catalog-model": "npm:^1.9.0"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/plugin-search-common": "npm:^1.2.24"
+  checksum: 10c0/189b51650bd5468ca71f4cd76fde50f52e364521f7d44369278f2e422be65b9dbb5366733dc70c192dd11ec0bad22aaf5cccfefd19d5afb1fd8a94335175c951
   languageName: node
   linkType: hard
 
@@ -2131,6 +2259,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-common@npm:^0.9.9":
+  version: 0.9.9
+  resolution: "@backstage/plugin-permission-common@npm:0.9.9"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/types": "npm:^1.2.2"
+    cross-fetch: "npm:^4.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10c0/f06156828391ff59b98c2e65d7943503fd1d18d9fd0b22b9df9bbbdeff90469233be1949d22acc9a7ca148c493ff52d2ecba78533702b60d208348c55eb9c720
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-permission-node@npm:^0.10.7, @backstage/plugin-permission-node@npm:^0.10.8":
   version: 0.10.8
   resolution: "@backstage/plugin-permission-node@npm:0.10.8"
@@ -2149,6 +2291,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-node@npm:^0.11.2":
+  version: 0.11.2
+  resolution: "@backstage/plugin-permission-node@npm:0.11.2"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:^1.9.3"
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@types/express": "npm:^4.17.6"
+    express: "npm:^4.22.0"
+    express-promise-router: "npm:^4.1.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10c0/70ac2494ff39fd55dfb82dad8f7be6fab91b0b21fdba3e978b2108b63cf4848f89f7bd38578629d71ddd072af7b3c4ad0c1d8916e20e4bdce88e8201c7e97d3d
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-search-common@npm:^1.2.21":
   version: 1.2.21
   resolution: "@backstage/plugin-search-common@npm:1.2.21"
@@ -2156,6 +2315,16 @@ __metadata:
     "@backstage/plugin-permission-common": "npm:^0.9.3"
     "@backstage/types": "npm:^1.2.2"
   checksum: 10c0/2372189f6747f32f76d4baf18038e885345a82cb4d678fd016c2929d38fca0ab733dab7a07d46bafb957aae5948de33c28d178bffb6b8b536845b4bbb83a01d5
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-common@npm:^1.2.24":
+  version: 1.2.24
+  resolution: "@backstage/plugin-search-common@npm:1.2.24"
+  dependencies:
+    "@backstage/plugin-permission-common": "npm:^0.9.9"
+    "@backstage/types": "npm:^1.2.2"
+  checksum: 10c0/ff56a3797325d5b1f4658b1136a4ddb6cba29d7ebc78e039565cdc61e159ffb3b85c2688a04bfd516e639e22cdaf53043a97dadd8c7c4aed2c4739fa3d528e2e
   languageName: node
   linkType: hard
 
@@ -2524,7 +2693,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/catalog-backend-module-grafana-servicemodel@workspace:."
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.6.1"
+    "@backstage/backend-plugin-api": "npm:^1.8.0"
     "@backstage/backend-test-utils": "npm:^1.0.2"
     "@backstage/catalog-model": "npm:^1.7.6"
     "@backstage/cli": "npm:^0.35.1"
@@ -6440,6 +6609,15 @@ __metadata:
     ajv:
       optional: true
   checksum: 10c0/6044310bd38c17d77549fd326bd40ce1506fa10b0794540aa130180808bf94117fac8c9b448c621512bea60e4a947278f6a978e87f10d342950c15b33ddd9271
+  languageName: node
+  linkType: hard
+
+"ajv-errors@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "ajv-errors@npm:3.0.0"
+  peerDependencies:
+    ajv: ^8.0.1
+  checksum: 10c0/f3d864ebd4bc0b51ad622b5a889cc8903000295eaa058d59c2102f293fe126c3d901419da143eaa817b863cac2e92ae2ef6f55e6c31d07bf272099afe73961ae
   languageName: node
   linkType: hard
 
@@ -19872,10 +20050,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.22.4":
+"zod-validation-error@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "zod-validation-error@npm:5.0.0"
+  peerDependencies:
+    zod: ^3.25.0 || ^4.0.0
+  checksum: 10c0/1f137003dad6da34e954e31f270ea8bf2cc6e29dbb9b03858951f6498a7f728b935ca66782514b2fca6485750844cef4633ce1acbd17ad3dde359a2ad6b22973
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.22.4, zod@npm:^3.25.76":
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25.76 || ^4.0.0":
+  version: 4.4.3
+  resolution: "zod@npm:4.4.3"
+  checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1683,27 +1683,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:^1.8.0, @backstage/backend-plugin-api@npm:^1.9.3":
-  version: 1.9.3
-  resolution: "@backstage/backend-plugin-api@npm:1.9.3"
-  dependencies:
-    "@backstage/cli-common": "npm:^0.3.0"
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/plugin-auth-node": "npm:^0.7.3"
-    "@backstage/plugin-permission-common": "npm:^0.9.9"
-    "@backstage/plugin-permission-node": "npm:^0.11.2"
-    "@backstage/types": "npm:^1.2.2"
-    "@types/express": "npm:^4.17.6"
-    "@types/json-schema": "npm:^7.0.6"
-    "@types/luxon": "npm:^3.0.0"
-    knex: "npm:^3.0.0"
-    luxon: "npm:^3.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-  checksum: 10c0/cf8547920e88bc94b812aae4b93a2d68dcf8e1cba0aa9065ca4530b795f6e89a9ec8e184a4e44ed342612ec2bb4fb25e195325a25b08edd1264b3e2de76208c2
-  languageName: node
-  linkType: hard
-
 "@backstage/backend-test-utils@npm:^1.0.2":
   version: 1.10.3
   resolution: "@backstage/backend-test-utils@npm:1.10.3"
@@ -1756,21 +1735,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-client@npm:^1.16.1":
-  version: 1.16.1
-  resolution: "@backstage/catalog-client@npm:1.16.1"
-  dependencies:
-    "@backstage/catalog-model": "npm:^1.9.0"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/filter-predicates": "npm:^0.1.4"
-    "@backstage/plugin-catalog-common": "npm:^1.1.10"
-    cross-fetch: "npm:^4.0.0"
-    lodash: "npm:^4.17.21"
-    uri-template: "npm:^2.0.0"
-  checksum: 10c0/4b00fbada78234dd7a17863cef6134193b6d0396888cbcbfcda397d7321c594826f4f092d6bd6ac725e32a91ac3baf44a53a3bab5645ac7ef7c7ee803388f64f
-  languageName: node
-  linkType: hard
-
 "@backstage/catalog-model@npm:^1.7.6":
   version: 1.7.6
   resolution: "@backstage/catalog-model@npm:1.7.6"
@@ -1783,20 +1747,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@npm:^1.9.0":
-  version: 1.9.0
-  resolution: "@backstage/catalog-model@npm:1.9.0"
-  dependencies:
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/types": "npm:^1.2.2"
-    ajv: "npm:^8.10.0"
-    ajv-errors: "npm:^3.0.0"
-    lodash: "npm:^4.17.21"
-    zod: "npm:^3.25.76"
-  checksum: 10c0/05ae984123b56d830861f23c428c11e2e62b273757fcef318afe26e361f09c2bc87976dfea602bf0933fafa82955bc31e6ac0f4e8ab7bcaa583ea4755da4239f
-  languageName: node
-  linkType: hard
-
 "@backstage/cli-common@npm:^0.1.16, @backstage/cli-common@npm:^0.1.17":
   version: 0.1.17
   resolution: "@backstage/cli-common@npm:0.1.17"
@@ -1806,16 +1756,6 @@ __metadata:
     global-agent: "npm:^3.0.0"
     undici: "npm:^7.2.3"
   checksum: 10c0/85dc7c7ecfbd1dc47f83b6a320a09c83773f9a6357b4186bbf53541f1f58db6dc576ed7de84c1285e38fdbe9c02851b63f48dd4474845f36fe3f33dc4ecb28e9
-  languageName: node
-  linkType: hard
-
-"@backstage/cli-common@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "@backstage/cli-common@npm:0.3.0"
-  dependencies:
-    "@backstage/errors": "npm:^1.3.1"
-    cross-spawn: "npm:^7.0.3"
-  checksum: 10c0/c6ae3bf3697bf463e0043150c0e56e4075ff9fd516e786593845c02de47ee72c4dad64cc1cfd9f54685b11ba9ed075ffa11eb764cc65da58ca3367da18a5dca1
   languageName: node
   linkType: hard
 
@@ -2015,17 +1955,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@npm:^1.3.8":
-  version: 1.3.8
-  resolution: "@backstage/config@npm:1.3.8"
-  dependencies:
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/types": "npm:^1.2.2"
-    ms: "npm:^2.1.3"
-  checksum: 10c0/bd9e1fdd7ab8e56a9814a7f67502ed69f9abd0f014dae44d253a6a02c0c6bf844451d037afa991b200fc09d89e7195593bd5a9459357dafd8101dc826e664dec
-  languageName: node
-  linkType: hard
-
 "@backstage/errors@npm:^1.2.7":
   version: 1.2.7
   resolution: "@backstage/errors@npm:1.2.7"
@@ -2036,16 +1965,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/errors@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "@backstage/errors@npm:1.3.1"
-  dependencies:
-    "@backstage/types": "npm:^1.2.2"
-    serialize-error: "npm:^8.0.1"
-  checksum: 10c0/b342551f5337f17bcc6d412868f6274509d657cc6037fbb5af96d42156c24c2419e72fd711136e42d05245bd4e5c5d8fe9cd54f89f260d9285a073c28cca0261
-  languageName: node
-  linkType: hard
-
 "@backstage/eslint-plugin@npm:^0.2.0":
   version: 0.2.0
   resolution: "@backstage/eslint-plugin@npm:0.2.0"
@@ -2053,19 +1972,6 @@ __metadata:
     "@manypkg/get-packages": "npm:^1.1.3"
     minimatch: "npm:^9.0.0"
   checksum: 10c0/7f57cd42629084b0363cf9adb37d33479fd540226a29705da623db9032890a6e67d1eb15b8076ea2fe3b502e36810ad819c93936406524e56e33801b561d6ff3
-  languageName: node
-  linkType: hard
-
-"@backstage/filter-predicates@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "@backstage/filter-predicates@npm:0.1.4"
-  dependencies:
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/types": "npm:^1.2.2"
-    zod: "npm:^3.25.76 || ^4.0.0"
-    zod-validation-error: "npm:^5.0.0"
-  checksum: 10c0/0e54760800797c45df47f58f0c1138cd2667939f0d1a4b83c63466fed82b293ffc144751bf98684b2e61edcc111c1cb34ebf607f19befd361e9b8f061f04d1cc
   languageName: node
   linkType: hard
 
@@ -2125,29 +2031,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-node@npm:^0.7.3":
-  version: 0.7.3
-  resolution: "@backstage/plugin-auth-node@npm:0.7.3"
-  dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.9.3"
-    "@backstage/catalog-client": "npm:^1.16.1"
-    "@backstage/catalog-model": "npm:^1.9.0"
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/types": "npm:^1.2.2"
-    "@types/express": "npm:^4.17.6"
-    "@types/passport": "npm:^1.0.3"
-    express: "npm:^4.22.0"
-    jose: "npm:^5.0.0"
-    lodash: "npm:^4.17.21"
-    passport: "npm:^0.7.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-    zod-to-json-schema: "npm:^3.25.1"
-    zod-validation-error: "npm:^5.0.0"
-  checksum: 10c0/faf274cc6d13193ef8aa6daa8dba33219ee8661029e603c6eb8e80f3ed7a35860a7b5603b2667c61b9c2df976a1ede836467ee3a94be08b4b31cb910fea10f90
-  languageName: node
-  linkType: hard
-
 "@backstage/plugin-catalog-backend@npm:^3.3.1":
   version: 3.3.1
   resolution: "@backstage/plugin-catalog-backend@npm:3.3.1"
@@ -2184,17 +2067,6 @@ __metadata:
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
   checksum: 10c0/1a0cb3ff464e34f0b48d2be83933e2f4950a16808ccb9159e701f16116a80235a2e9998aefc48a5df9ef11df43341a6b16761ba182c2407e7e8f457967f81b0c
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-catalog-common@npm:^1.1.10":
-  version: 1.1.10
-  resolution: "@backstage/plugin-catalog-common@npm:1.1.10"
-  dependencies:
-    "@backstage/catalog-model": "npm:^1.9.0"
-    "@backstage/plugin-permission-common": "npm:^0.9.9"
-    "@backstage/plugin-search-common": "npm:^1.2.24"
-  checksum: 10c0/189b51650bd5468ca71f4cd76fde50f52e364521f7d44369278f2e422be65b9dbb5366733dc70c192dd11ec0bad22aaf5cccfefd19d5afb1fd8a94335175c951
   languageName: node
   linkType: hard
 
@@ -2259,20 +2131,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-common@npm:^0.9.9":
-  version: 0.9.9
-  resolution: "@backstage/plugin-permission-common@npm:0.9.9"
-  dependencies:
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/types": "npm:^1.2.2"
-    cross-fetch: "npm:^4.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-    zod-to-json-schema: "npm:^3.25.1"
-  checksum: 10c0/f06156828391ff59b98c2e65d7943503fd1d18d9fd0b22b9df9bbbdeff90469233be1949d22acc9a7ca148c493ff52d2ecba78533702b60d208348c55eb9c720
-  languageName: node
-  linkType: hard
-
 "@backstage/plugin-permission-node@npm:^0.10.7, @backstage/plugin-permission-node@npm:^0.10.8":
   version: 0.10.8
   resolution: "@backstage/plugin-permission-node@npm:0.10.8"
@@ -2291,23 +2149,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-node@npm:^0.11.2":
-  version: 0.11.2
-  resolution: "@backstage/plugin-permission-node@npm:0.11.2"
-  dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.9.3"
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/plugin-permission-common": "npm:^0.9.9"
-    "@types/express": "npm:^4.17.6"
-    express: "npm:^4.22.0"
-    express-promise-router: "npm:^4.1.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-    zod-to-json-schema: "npm:^3.25.1"
-  checksum: 10c0/70ac2494ff39fd55dfb82dad8f7be6fab91b0b21fdba3e978b2108b63cf4848f89f7bd38578629d71ddd072af7b3c4ad0c1d8916e20e4bdce88e8201c7e97d3d
-  languageName: node
-  linkType: hard
-
 "@backstage/plugin-search-common@npm:^1.2.21":
   version: 1.2.21
   resolution: "@backstage/plugin-search-common@npm:1.2.21"
@@ -2315,16 +2156,6 @@ __metadata:
     "@backstage/plugin-permission-common": "npm:^0.9.3"
     "@backstage/types": "npm:^1.2.2"
   checksum: 10c0/2372189f6747f32f76d4baf18038e885345a82cb4d678fd016c2929d38fca0ab733dab7a07d46bafb957aae5948de33c28d178bffb6b8b536845b4bbb83a01d5
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-search-common@npm:^1.2.24":
-  version: 1.2.24
-  resolution: "@backstage/plugin-search-common@npm:1.2.24"
-  dependencies:
-    "@backstage/plugin-permission-common": "npm:^0.9.9"
-    "@backstage/types": "npm:^1.2.2"
-  checksum: 10c0/ff56a3797325d5b1f4658b1136a4ddb6cba29d7ebc78e039565cdc61e159ffb3b85c2688a04bfd516e639e22cdaf53043a97dadd8c7c4aed2c4739fa3d528e2e
   languageName: node
   linkType: hard
 
@@ -2693,7 +2524,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/catalog-backend-module-grafana-servicemodel@workspace:."
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.8.0"
+    "@backstage/backend-plugin-api": "npm:^1.6.1"
     "@backstage/backend-test-utils": "npm:^1.0.2"
     "@backstage/catalog-model": "npm:^1.7.6"
     "@backstage/cli": "npm:^0.35.1"
@@ -2703,6 +2534,7 @@ __metadata:
     "@backstage/plugin-catalog-common": "npm:^1.1.7"
     "@backstage/plugin-catalog-node": "npm:^1.20.1"
     "@kubernetes/client-node": "npm:^1.1.2"
+    "@opentelemetry/api": "npm:^1.9.0"
     "@spotify/prettier-config": "npm:^15.0.0"
     "@types/jest": "npm:^29.5.14"
     "@types/lodash": "npm:^4.14.202"
@@ -6609,15 +6441,6 @@ __metadata:
     ajv:
       optional: true
   checksum: 10c0/6044310bd38c17d77549fd326bd40ce1506fa10b0794540aa130180808bf94117fac8c9b448c621512bea60e4a947278f6a978e87f10d342950c15b33ddd9271
-  languageName: node
-  linkType: hard
-
-"ajv-errors@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "ajv-errors@npm:3.0.0"
-  peerDependencies:
-    ajv: ^8.0.1
-  checksum: 10c0/f3d864ebd4bc0b51ad622b5a889cc8903000295eaa058d59c2102f293fe126c3d901419da143eaa817b863cac2e92ae2ef6f55e6c31d07bf272099afe73961ae
   languageName: node
   linkType: hard
 
@@ -20050,26 +19873,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-validation-error@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "zod-validation-error@npm:5.0.0"
-  peerDependencies:
-    zod: ^3.25.0 || ^4.0.0
-  checksum: 10c0/1f137003dad6da34e954e31f270ea8bf2cc6e29dbb9b03858951f6498a7f728b935ca66782514b2fca6485750844cef4633ce1acbd17ad3dde359a2ad6b22973
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.22.4, zod@npm:^3.25.76":
+"zod@npm:^3.22.4":
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.25.76 || ^4.0.0":
-  version: 4.4.3
-  resolution: "zod@npm:4.4.3"
-  checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

The processor writes only to the logger today, so the only way to tell whether a sync is healthy is to read logs. That works for investigating one failure but does not scale: a silent stall — expired token, sustained 429s, a connection that never returns — looks identical to a quiet, healthy sync.

This adds instruments over the sync loop, the ServiceModel API calls, and the connection state, so **"did the last sync succeed?" is answerable from a dashboard**.

**No public API change, no minimum-version change.** `module.ts` is untouched and `fromConfig` keeps its current signature.

## Instruments

| Metric | Type | Attributes |
|---|---|---|
| `grafana_servicemodel.entities.processed` | Counter | `kind` |
| `grafana_servicemodel.entities.synced` | Counter | `kind`, `operation` |
| `grafana_servicemodel.entities.skipped` | Counter | `kind`, `reason` |
| `grafana_servicemodel.entities.failed` | Counter | `kind`, `code` |
| `grafana_servicemodel.sync.duration` | Histogram | `kind`, `outcome` |
| `grafana_servicemodel.api.requests` | Counter | `operation`, `code` |
| `grafana_servicemodel.connection.attempts` | Counter | `outcome` |
| `grafana_servicemodel.connection.state` | Observable gauge | – |

`operation` on `entities.synced` separates `create` / `update` / `noop`; `reason` on `entities.skipped` separates `filtered` / `unchanged` / `disconnected`, so cache effectiveness and outage impact are both visible. Full details and example PromQL in [`docs/metrics.md`](docs/metrics.md).

## Why the OpenTelemetry API and not `MetricsService`

I first wrote this against Backstage's alpha `MetricsService`, which is the more idiomatic choice. **It does not work today**, and I want to be upfront that my first push of this PR would have broken every consumer:

- `metricsServiceRef` is `createServiceRef({id: 'alpha.core.metrics'})` with **no `defaultFactory`**
- **No released `@backstage/backend-defaults` implements `alpha.core.metrics`** — I checked 0.15.0 and 0.17.5; neither has a metrics entrypoint
- `BackendInitializer.#getInitDeps` **throws** on an unresolved ref, which aborts startup for the entire backend, not just this module

So declaring it as a `registerInit` dep is a guaranteed boot failure, and Backstage has no optional-dependency mechanism to soften it. Same class of bug as #160.

Instruments now come from the global OpenTelemetry meter. When no `MeterProvider` is registered the API returns no-op instruments (verified: `NoopMeter`, `NoopCounterMetric`), so an install that never configured OpenTelemetry is genuinely unaffected. Exporter setup stays the deployer's concern, per Backstage's own OpenTelemetry guide. Migrating to `MetricsService` later is a one-file change.

Happy to be told you'd rather wait for `MetricsService` to ship an implementation and hold this — but the current PR is safe either way.

## Two behaviour fixes the metrics forced

Both are cases where the code reported success for a write that did not land. I could not make the metrics truthful without them, so they are in scope; neither changes error-handling behaviour, and catalog processing still cannot be interrupted.

1. **`createModel` swallowed a failed create and resolved anyway**, so `createOrUpdateModel` returned `true`. The entity was counted as failed *and* recorded a success-latency sample, then cached as written — which stopped it being retried, so the failure disappeared after one cycle. A "create errors stopped" dashboard reading would have been wrong. `createModel` now returns whether the object is actually present; the error is still not rethrown.
2. **The same reporting bug on the update path**, found by mutation testing.

## Testing

44 tests. A fake ServiceModel client exercises the real create / update / noop paths rather than stubbing `createOrUpdateModel`, and a controlled clock pins `sync.duration` to seconds.

I hand-ran mutation testing to check the tests actually hold. Thirteen mutations initially survived undetected — including `entities.synced` and `api.requests` having *no* coverage at all, and a ms-vs-seconds unit swap passing because the assertion was only `>= 0`. All are now caught.

`yarn lint`, `yarn tsc`, `yarn build` clean.

## Also worth flagging (not fixed here)

Two pre-existing issues this instrumentation made visible, which I've left alone as out of scope — happy to send either separately:

- **`cache.get(...).then(...)` has no `.catch`** in `postProcessEntity`. A cache read rejection leaves the returned promise permanently unsettled, stalling that entity.
- **The `isConnecting` mutex is a no-op** — `return new Promise(...)` inside the `try` runs `finally` before the promise settles, so the early-return path records a connection attempt that never happened and inflates the backoff.

## Context

We run this against a ~4800-entity catalog. After v0.3.41 the plugin behaves well, but we still cannot answer basic operational questions without log queries. Metrics were the last item on our production-readiness list.
